### PR TITLE
correcting parameter docs

### DIFF
--- a/documentation/serverless/serverless-parameters.mdx
+++ b/documentation/serverless/serverless-parameters.mdx
@@ -71,9 +71,7 @@ If not specified during endpoint creation, the default value is 0.9.
 
 The following parameters can be specified specifically for a Workergroup and override Endpoint parameters. The Endpoint parameters will continue to apply for other Workergroups contained in it, unless specifically set.&#x20;
 
-- min\_load
-- target\_util
-- cold\_mult
+- cold\_workers
 
 The parameters below are specific to only Workergroups, not Endpoints.
 
@@ -112,12 +110,6 @@ There is no default value for template\_hash.
 A numeric (integer) identifier that uniquely references a template in the Vast.ai database. This is an alternative way to reference the same template that `template_hash` points to, but using the template's database primary key instead of its hash string.
 
 There is no default value for template\_id.
-
-## test\_workers
-
-The number of different physical machines that a Workergroup should test during its initial "exploration" phase to gather performance data before transitioning to normal demand-based scaling. The Worker Group remains in "exploring" mode until it has successfully tested at least `floor(test_workers / 2)` machines.
-
-If not specified during workergroup creation, the default value is 3.
 
 
 


### PR DESCRIPTION
cold_workers is the only workergroup level parameter that overrides endptgroup parameters

test_workers no longer exists