### PR TITLE
CLN-2792: remove disable-bundling from docs

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -8443,10 +8443,6 @@
                     "minItems": 2,
                     "maxItems": 2
                   },
-                  "disable_bundling": {
-                    "type": "boolean",
-                    "description": "Disable offer bundling"
-                  },
                   "allocated_storage": {
                     "type": "number",
                     "description": "Storage allocation size in GB for the instance.\nThis sets the disk size when creating the instance and cannot be changed later.\nDefault is 8GB.\n"

--- a/cli/commands.mdx
+++ b/cli/commands.mdx
@@ -1037,8 +1037,6 @@ options:
   -r, --reserved        Alias for --type=reserved
   -d, --on-demand       Alias for --type=on-demand
   -n, --no-default      Disable default query
-  --disable-bundling    Show identical offers. This request is more heavily
-                        rate limited.
   --storage STORAGE     Amount of storage to use for pricing, in GiB.
                         default=5.0GiB
   -o ORDER, --order ORDER


### PR DESCRIPTION
## Summary
- Remove `--disable-bundling` from CLI help text in `cli/commands.mdx`
- Remove `disable_bundling` field from OpenAPI JSON schema in `api-reference/openapi.json`

## Test plan
- [ ] Docs build successfully without references to disable-bundling

🤖 Generated with [Claude Code](https://claude.com/claude-code)