### PR TITLE
bugfix - unescaped $ in tax guide MDX causing garbled text

### DIFF
--- a/documentation/host/guide-to-taxes.mdx
+++ b/documentation/host/guide-to-taxes.mdx
@@ -15,7 +15,7 @@ updatedAt: Wed Jan 15 2025 00:36:52 GMT+0000 (Coordinated Universal Time)
         "name": "What is Stripe Express, and how do I access it?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Stripe Express allows you to update your tax information, manage tax forms, and track your earnings. If you're working with Vast.ai and earned $600 or more (within the calendar year in the US), Stripe will send an email inviting you to create an account and log in to Stripe Express."
+          "text": "Stripe Express allows you to update your tax information, manage tax forms, and track your earnings. If you're working with Vast.ai and earned \$600 or more (within the calendar year in the US), Stripe will send an email inviting you to create an account and log in to Stripe Express."
         }
       },
       {
@@ -72,7 +72,7 @@ Vast.ai does not provide any tax documents or tax advice to hosts that reside an
 
 # United States
 
-If you earned $600 or more in 2023 on the Vast.ai platform as a host, Vast.ai will send a 1099-MISC or 1099-K form to you either through our partner Stripe Connect, PayPal or another method. If you have a question or issue, email us at [contact@vast.ai](mailto\:contact@vast.ai).
+If you earned \$600 or more in 2023 on the Vast.ai platform as a host, Vast.ai will send a 1099-MISC or 1099-K form to you either through our partner Stripe Connect, PayPal or another method. If you have a question or issue, email us at [contact@vast.ai](mailto\:contact@vast.ai).
 
 ## Wise
 
@@ -134,7 +134,7 @@ You may not have received an invitation for other reasons, such as:
 
 ### Will I receive a 1099 form?
 
-If you earned less than $600 over the course of the year, you may not receive a 1099 form and one won’t be generated for you unless you meet a threshold in your state. If your state has a filing threshold lower than $600, you might receive a 1099 form.
+If you earned less than \$600 over the course of the year, you may not receive a 1099 form and one won’t be generated for you unless you meet a threshold in your state. If your state has a filing threshold lower than \$600, you might receive a 1099 form.
 
 You can check your state’s requirements here: View [1099 state requirements](https://stripe.com/docs/connect/tax-forms-state-requirements#check-1099-form-requirements-by-state).
 


### PR DESCRIPTION
using dollar signs in guide-to-taxes.mdx gettin read as JSX expressions causing text to concatenate into one long line

<img width="1630" height="546" alt="Screenshot from 2026-03-02 13-38-08" src="https://github.com/user-attachments/assets/602db011-fd4a-47bf-8b25-9437697a1e34" />