### PR TITLE
fix autoresearch template link

### DIFF
--- a/examples/ai-agents/autoresearch.mdx
+++ b/examples/ai-agents/autoresearch.mdx
@@ -97,7 +97,7 @@ Autoresearch requires a single NVIDIA GPU with 80GB VRAM (H100 or A100 80GB). It
 
 <Tabs>
   <Tab title="Use Template">
-    Use the [Autoresearcher template](https://cloud.vast.ai?template_id=934769670bfd9bc5e05d8696ef340c2b) to launch a pre-configured instance with uv, Claude Code, and autoresearch already installed.
+    Use the [Autoresearcher template](https://cloud.vast.ai/?ref_id=146798&creator_id=146798&name=Autoresearcher%20(Claude%20Code)) to launch a pre-configured instance with uv, Claude Code, and autoresearch already installed.
 
     <Card title="Learn more about templates" href="/documentation/templates/introduction" icon="layer-group">
       Templates are reusable configurations that bundle a Docker image, environment variables, and startup scripts into a one-click launch.


### PR DESCRIPTION
Change autoresearch template link to permanent referral link 
https://cloud.vast.ai/?ref_id=146798&creator_id=146798&name=Autoresearcher%20(Claude%20Code)