### PR TITLE
docs(CLN-3285): un-publish 2FA developer reference from public docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -560,7 +560,6 @@
               "api-reference/introduction",
               "api-reference/authentication",
               "api-reference/permissions",
-              "api-reference/two-factor-authentication",
               "api-reference/two-factor-authentication-endpoints",
               "api-reference/rate-limits-and-errors"
             ]


### PR DESCRIPTION
## Summary

Removes \`api-reference/two-factor-authentication\` from \`docs.json\` so the page stops rendering at https://docs.vast.ai/api-reference/two-factor-authentication.

## Why

The page is currently published publicly but contains non-public implementation detail:
- Lockout thresholds (\`{sms: 3, totp: 5}\` + 15-min duration) — operationally sensitive; tells brute-force attackers how to pace under threshold
- Internal source-code references — \`auth.py\`, \`get_tfa_status\`, \`_handle_legacy_tfa_deletion\`
- Database schema — \`user_tfa_methods\` table, \`users.tfa_enabled\`, \`users.phone_number\`
- Redis cache keys — \`new_method_preauth_success:{user_id}\` + 30-min TTL
- Legacy attack-surface details — deprecated \`/test-submit/\` endpoint behavior + \`untracked_2fa_found\` branch

## Scope

Surgical: drop one line from \`docs.json\`. The file itself stays on disk.

## Out of scope (separate tickets)

- File deletion or content redaction
- Internal relocation (Confluence / internal docs site / wherever it should live)
- CLN-2800 AC #1 satisfaction status

## Test plan

- [ ] \`docs.json\` JSON is valid (verified locally)
- [ ] After merge + Mintlify deploy, \`docs.vast.ai/api-reference/two-factor-authentication\` returns 404
- [ ] Sibling pages (\`api-reference/two-factor-authentication-endpoints\`, others in the same group) continue to render

Refs: [CLN-3285](https://vastai.atlassian.net/browse/CLN-3285), CLN-2800