### PR TITLE
Add redirects for legacy docs paths

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1160,6 +1160,10 @@
       "destination": "/guides/templates/creating-templates"
     },
     {
+      "source": "/create-template-with-your-own-image",
+      "destination": "/guides/templates/creating-templates"
+    },
+    {
       "source": "/guides/templates/customization-guide",
       "destination": "/guides/templates/advanced-setup"
     },
@@ -1198,6 +1202,26 @@
     {
       "source": "/api-reference/python-sdk-usage",
       "destination": "/sdk/python/quickstart"
+    },
+    {
+      "source": "/serverless/debugging",
+      "destination": "/guides/serverless/logging"
+    },
+    {
+      "source": "/serverless/inside-a-serverless-gpu",
+      "destination": "/guides/serverless/overview"
+    },
+    {
+      "source": "/serverless/performance-tracking",
+      "destination": "/guides/serverless/automated-performance-testing"
+    },
+    {
+      "source": "/serverless/logs",
+      "destination": "/api-reference/serverless/get-endpoint-logs"
+    },
+    {
+      "source": "/serverless/worker-list",
+      "destination": "/api-reference/serverless/get-endpoint-workers"
     },
     {
       "source": "/instances/:slug*",


### PR DESCRIPTION
```md
## Summary

Adds Mintlify redirects for legacy direct `docs.vast.ai` URLs that were still returning 404s.

This complements the `vast_landing` redirect fix by covering users, crawlers, or old links that go directly to `docs.vast.ai/...` instead of passing through the app redirect layer.

## Changes

- Redirect `/create-template-with-your-own-image` to `/guides/templates/creating-templates`
- Redirect legacy `/serverless/...` paths to current serverless guide or API reference pages
- Keeps the change scoped to `docs.json` only

## Validation

- Confirmed `docs.json` parses successfully
- Confirmed no duplicate redirect sources
- Confirmed all new redirect destinations return `200`
- Could not run `mint broken-links` locally because the `mint` CLI is not installed
```