### PR TITLE
Add redirects for spreadsheet 404s

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -928,6 +928,78 @@
       "destination": "/guides/serverless/automated-performance-testing"
     },
     {
+      "source": "/guides/serverless/endpoint-scaling-parameters",
+      "destination": "/guides/serverless/serverless-parameters"
+    },
+    {
+      "source": "/guides/serverless/worker-py",
+      "destination": "/guides/serverless/creating-new-pyworkers"
+    },
+    {
+      "source": "/guides/stable-diffusion",
+      "destination": "/stable-diffusion"
+    },
+    {
+      "source": "/v1/embeddings",
+      "destination": "/guides/serverless/openai-compatible-api"
+    },
+    {
+      "source": "/v1/models",
+      "destination": "/guides/serverless/openai-compatible-api"
+    },
+    {
+      "source": "/v1/images",
+      "destination": "/guides/serverless/openai-compatible-api"
+    },
+    {
+      "source": "/asr",
+      "destination": "/whisper-asr-guide"
+    },
+    {
+      "source": "/detect-language",
+      "destination": "/whisper-asr-guide"
+    },
+    {
+      "source": "/extract",
+      "destination": "/examples/embeddings/serving-rerankers-vllm"
+    },
+    {
+      "source": "/score",
+      "destination": "/examples/embeddings/serving-rerankers-vllm"
+    },
+    {
+      "source": "/rerank",
+      "destination": "/examples/embeddings/serving-rerankers-vllm"
+    },
+    {
+      "source": "/search-and-filter-gpu-offers",
+      "destination": "/guides/instances/choosing/find-and-rent"
+    },
+    {
+      "source": "/login",
+      "destination": "/guides/get-started"
+    },
+    {
+      "source": "/health",
+      "destination": "/guides/get-started"
+    },
+    {
+      "source": "/stop",
+      "destination": "/cli/reference/stop-instance"
+    },
+    {
+      "source": "/create-your-own-multi-node-cluster",
+      "destination": "/multi-node-training-using-torch-nccl"
+    },
+    {
+      "source": "/data-management/trash",
+      "destination": "/guides/instances/storage/volumes"
+    },
+    {
+      "source": "/data-management/trash/",
+      "destination": "/guides/instances/storage/volumes"
+    },
+    {
       "source": "/datacenter-status",
       "destination": "/host/datacenter-status"
     },
@@ -1224,6 +1296,18 @@
       "destination": "/api-reference/serverless/get-endpoint-workers"
     },
     {
+      "source": "/serverless/getting-started",
+      "destination": "/guides/serverless/quickstart"
+    },
+    {
+      "source": "/instances/templates",
+      "destination": "/guides/instances/choosing/templates"
+    },
+    {
+      "source": "/instances/docker-execution-environment",
+      "destination": "/guides/instances/docker-environment"
+    },
+    {
       "source": "/instances/:slug*",
       "destination": "/guides/instances/:slug*"
     },
@@ -1252,8 +1336,212 @@
       "destination": "/api-reference/introduction"
     },
     {
+      "source": "/api/search-offers",
+      "destination": "/api-reference/search/search-offers"
+    },
+    {
+      "source": "/api/create-instance",
+      "destination": "/api-reference/instances/create-instance"
+    },
+    {
+      "source": "/api/launch-an-instance",
+      "destination": "/api-reference/instances/create-instance"
+    },
+    {
+      "source": "/api/destroy-an-instance",
+      "destination": "/api-reference/instances/destroy-instance"
+    },
+    {
+      "source": "/api/change-bid-price",
+      "destination": "/api-reference/instances/change-bid"
+    },
+    {
+      "source": "/api/schedule-maintenance",
+      "destination": "/api-reference/machines/schedule-maint"
+    },
+    {
+      "source": "/api/update-autogroup.md",
+      "destination": "/api-reference/serverless/update-workergroup"
+    },
+    {
+      "source": "/api/delete-autogroup.md",
+      "destination": "/api-reference/serverless/delete-workergroup"
+    },
+    {
+      "source": "/api/retrieve-team-roles",
+      "destination": "/api-reference/team/show-team-roles"
+    },
+    {
+      "source": "/api/show-endpoints.md",
+      "destination": "/api-reference/serverless/show-endpoints"
+    },
+    {
+      "source": "/api/update-endpoint.md",
+      "destination": "/api-reference/serverless/update-endpoint"
+    },
+    {
+      "source": "/api/invite-a-new-member-to-join-a-team",
+      "destination": "/api-reference/team/invite-team-member"
+    },
+    {
+      "source": "/api/v0/tfa",
+      "destination": "/api-reference/two-factor-authentication-endpoints"
+    },
+    {
+      "source": "/api/v0/tfa/",
+      "destination": "/api-reference/two-factor-authentication-endpoints"
+    },
+    {
+      "source": "/api/v0/tfa/status",
+      "destination": "/api-reference/two-factor-authentication-endpoints"
+    },
+    {
+      "source": "/api/v0/tfa/status/",
+      "destination": "/api-reference/two-factor-authentication-endpoints"
+    },
+    {
+      "source": "/api/v0/tfa/sms",
+      "destination": "/api-reference/two-factor-authentication-endpoints"
+    },
+    {
+      "source": "/api/v0/tfa/sms/",
+      "destination": "/api-reference/two-factor-authentication-endpoints"
+    },
+    {
+      "source": "/api/v0/tfa/sms/resend",
+      "destination": "/api-reference/two-factor-authentication-endpoints"
+    },
+    {
+      "source": "/api/v0/tfa/sms/resend/",
+      "destination": "/api-reference/two-factor-authentication-endpoints"
+    },
+    {
+      "source": "/api/v0/tfa/totp-setup",
+      "destination": "/api-reference/two-factor-authentication-endpoints"
+    },
+    {
+      "source": "/api/v0/tfa/totp-setup/",
+      "destination": "/api-reference/two-factor-authentication-endpoints"
+    },
+    {
+      "source": "/api/v0/tfa/confirm-new",
+      "destination": "/api-reference/two-factor-authentication-endpoints"
+    },
+    {
+      "source": "/api/v0/tfa/confirm-new/",
+      "destination": "/api-reference/two-factor-authentication-endpoints"
+    },
+    {
+      "source": "/api/v0/tfa/test-submit",
+      "destination": "/api-reference/two-factor-authentication-endpoints"
+    },
+    {
+      "source": "/api/v0/tfa/test-submit/",
+      "destination": "/api-reference/two-factor-authentication-endpoints"
+    },
+    {
+      "source": "/api/v0/tfa/regen-backup-codes",
+      "destination": "/api-reference/two-factor-authentication-endpoints"
+    },
+    {
+      "source": "/api/v0/tfa/regen-backup-codes/",
+      "destination": "/api-reference/two-factor-authentication-endpoints"
+    },
+    {
+      "source": "/api/v0/tfa/email",
+      "destination": "/api-reference/two-factor-authentication-endpoints"
+    },
+    {
+      "source": "/api/v0/tfa/email/",
+      "destination": "/api-reference/two-factor-authentication-endpoints"
+    },
+    {
+      "source": "/api/v0/tfa/update",
+      "destination": "/api-reference/two-factor-authentication-endpoints"
+    },
+    {
+      "source": "/api/v0/tfa/update/",
+      "destination": "/api-reference/two-factor-authentication-endpoints"
+    },
+    {
+      "source": "/api/v0/tfa/resend",
+      "destination": "/api-reference/two-factor-authentication-endpoints"
+    },
+    {
+      "source": "/api/v0/tfa/resend/",
+      "destination": "/api-reference/two-factor-authentication-endpoints"
+    },
+    {
+      "source": "/api/v0/tfa/authorize-new-method",
+      "destination": "/api-reference/two-factor-authentication-endpoints"
+    },
+    {
+      "source": "/api/v0/tfa/authorize-new-method/",
+      "destination": "/api-reference/two-factor-authentication-endpoints"
+    },
+    {
+      "source": "/api/v0/tfa/test",
+      "destination": "/api-reference/two-factor-authentication-endpoints"
+    },
+    {
+      "source": "/api/v0/tfa/test/",
+      "destination": "/api-reference/two-factor-authentication-endpoints"
+    },
+    {
+      "source": "/api/v0/machines/:machine_id/cleanup",
+      "destination": "/api-reference/machines/cleanup-machine"
+    },
+    {
+      "source": "/api/v0/machines/{machine_id}/cleanup",
+      "destination": "/api-reference/machines/cleanup-machine"
+    },
+    {
+      "source": "/api/v0/machines/{machine_id}/cleanup/",
+      "destination": "/api-reference/machines/cleanup-machine"
+    },
+    {
+      "source": "/api/v0/volumes/unlist",
+      "destination": "/api-reference/volumes/unlist-volume"
+    },
+    {
+      "source": "/api/v0/volumes/unlist/",
+      "destination": "/api-reference/volumes/unlist-volume"
+    },
+    {
+      "source": "/api/v0/team/roles",
+      "destination": "/api-reference/team/show-team-roles"
+    },
+    {
+      "source": "/api/v0/team/roles/",
+      "destination": "/api-reference/team/show-team-roles"
+    },
+    {
       "source": "/api/:slug*",
       "destination": "/api-reference/:slug*"
+    },
+    {
+      "source": "/api-reference/search/search-template",
+      "destination": "/api-reference/search/search-templates"
+    },
+    {
+      "source": "/api-reference/billing/search-invoices",
+      "destination": "/api-reference/billing/show-invoices"
+    },
+    {
+      "source": "/api-reference/machines/cleanup",
+      "destination": "/api-reference/machines/cleanup-machine"
+    },
+    {
+      "source": "/api-reference/show-subaccounts",
+      "destination": "/api-reference/accounts/show-subaccounts"
+    },
+    {
+      "source": "/tfa/totp-setup",
+      "destination": "/api-reference/two-factor-authentication-endpoints"
+    },
+    {
+      "source": "/tfa/totp-setup/",
+      "destination": "/api-reference/two-factor-authentication-endpoints"
     },
     {
       "source": "/serverless/templates-reference",
@@ -1282,6 +1570,46 @@
     {
       "source": "/documentation/host/:slug*",
       "destination": "/host/:slug*"
+    },
+    {
+      "source": "/documentation/serverless/logs",
+      "destination": "/guides/serverless/logging"
+    },
+    {
+      "source": "/documentation/serverless/worker-list",
+      "destination": "/api-reference/serverless/get-endpoint-workers"
+    },
+    {
+      "source": "/documentation/serverless/inside-a-serverless-gpu",
+      "destination": "/guides/serverless/overview"
+    },
+    {
+      "source": "/documentation/serverless/performance-testing",
+      "destination": "/guides/serverless/automated-performance-testing"
+    },
+    {
+      "source": "/documentation/serverless/debugging",
+      "destination": "/guides/serverless/logging"
+    },
+    {
+      "source": "/documentation/serverless/create-endpoints-and-workergroups",
+      "destination": "/guides/serverless/quickstart"
+    },
+    {
+      "source": "/documentation/serverless/endpoint-scaling-parameters",
+      "destination": "/guides/serverless/serverless-parameters"
+    },
+    {
+      "source": "/documentation/serverless/worker-py",
+      "destination": "/guides/serverless/creating-new-pyworkers"
+    },
+    {
+      "source": "/documentation/teams/transfer-team-ownership",
+      "destination": "/guides/teams/managing-teams"
+    },
+    {
+      "source": "/documentation/reference/host",
+      "destination": "/host/hosting-overview"
     },
     {
       "source": "/documentation/:slug*",


### PR DESCRIPTION
We added a second docs-side redirect pass for the stakeholder 404 spreadsheet. This covers the actionable direct docs.vast.ai 404s that can be safely fixed from the Mintlify docs repo: moved docs pages, legacy API reference paths, old serverless routes, old 2FA API routes, and clear product/doc paths.