### PR TITLE
redirect legacy urls and 404 urls, seo improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Vast.ai Docs: Pages
+# Vast.ai Documentation
 
-This directory contains the docs pages shown at [docs.vast.ai](https://docs.vast.ai), including the API reference.
+Source for [docs.vast.ai](https://docs.vast.ai), the official documentation for the Vast.ai GPU cloud marketplace. Covers renting or hosting GPU instances, deploying serverless inference workloads, and using the CLI, SDK, and REST API.
 
 ## Updating the API reference
 

--- a/cli/reference/list-volume.mdx
+++ b/cli/reference/list-volume.mdx
@@ -23,7 +23,7 @@ vastai list volume ID [options]
 ## Options
 
 <ParamField path="-p" type="number" default="0.1">
-  storage price in $/GB/month, default: $0.1/GB/month (alias: `--price_disk`)
+  storage price in \$/GB/month, default: \$0.1/GB/month (alias: `--price_disk`)
 </ParamField>
 
 <ParamField path="-e" type="string">

--- a/cli/reference/list-volumes.mdx
+++ b/cli/reference/list-volumes.mdx
@@ -23,7 +23,7 @@ vastai list volume IDs [options]
 ## Options
 
 <ParamField path="-p" type="number" default="0.1">
-  storage price in $/GB/month, default: $0.1/GB/month (alias: `--price_disk`)
+  storage price in \$/GB/month, default: \$0.1/GB/month (alias: `--price_disk`)
 </ParamField>
 
 <ParamField path="-e" type="string">

--- a/docs.json
+++ b/docs.json
@@ -1673,7 +1673,6 @@
       "color-scheme": "light dark",
       "format-detection": "telephone=no",
       "referrer": "origin",
-      "refresh": "30",
       "rating": "general",
       "revisit-after": "7 days",
       "language": "en",

--- a/docs.json
+++ b/docs.json
@@ -1517,7 +1517,7 @@
     },
     {
       "source": "/api/:slug*",
-      "destination": "/api-reference/:slug*"
+      "destination": "/api-reference/introduction"
     },
     {
       "source": "/api-reference/search/search-template",
@@ -1568,6 +1568,34 @@
       "destination": "/sdk/python/quickstart"
     },
     {
+      "source": "/documentation/serverless/logs",
+      "destination": "/guides/serverless/logging"
+    },
+    {
+      "source": "/documentation/serverless/worker-py",
+      "destination": "/guides/serverless/creating-new-pyworkers"
+    },
+    {
+      "source": "/documentation/serverless/endpoint-scaling-parameters",
+      "destination": "/guides/serverless/serverless-parameters"
+    },
+    {
+      "source": "/guides/serverless/worker-py",
+      "destination": "/guides/serverless/creating-new-pyworkers"
+    },
+    {
+      "source": "/guides/serverless/endpoint-scaling-parameters",
+      "destination": "/guides/serverless/serverless-parameters"
+    },
+    {
+      "source": "/instances/docker-execution-environment",
+      "destination": "/guides/instances/docker-environment"
+    },
+    {
+      "source": "/guides/stable-diffusion",
+      "destination": "/stable-diffusion"
+    },
+    {
       "source": "/documentation/host/:slug*",
       "destination": "/host/:slug*"
     },
@@ -1614,6 +1642,22 @@
     {
       "source": "/documentation/:slug*",
       "destination": "/guides/:slug*"
+    },
+    {
+      "source": "/api/update-autogroup.md",
+      "destination": "/api-reference/serverless/update-workergroup"
+    },
+    {
+      "source": "/api/delete-autogroup.md",
+      "destination": "/api-reference/serverless/delete-workergroup"
+    },
+    {
+      "source": "/api/show-endpoints.md",
+      "destination": "/api-reference/serverless/show-endpoints"
+    },
+    {
+      "source": "/api/update-endpoint.md",
+      "destination": "/api-reference/serverless/update-endpoint"
     }
   ],
   "seo": {

--- a/docs.json
+++ b/docs.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://mintlify.com/docs.json",
   "theme": "mint",
-  "name": "Vast.ai Documentation \u2013 Affordable GPU Cloud Marketplace",
+  "name": "Vast.ai Documentation: Affordable GPU Cloud Marketplace",
   "colors": {
     "primary": "#315FFF",
     "light": "#315FFF",
@@ -1580,28 +1580,8 @@
       "destination": "/guides/serverless/serverless-parameters"
     },
     {
-      "source": "/guides/serverless/worker-py",
-      "destination": "/guides/serverless/creating-new-pyworkers"
-    },
-    {
-      "source": "/guides/serverless/endpoint-scaling-parameters",
-      "destination": "/guides/serverless/serverless-parameters"
-    },
-    {
-      "source": "/instances/docker-execution-environment",
-      "destination": "/guides/instances/docker-environment"
-    },
-    {
-      "source": "/guides/stable-diffusion",
-      "destination": "/stable-diffusion"
-    },
-    {
       "source": "/documentation/host/:slug*",
       "destination": "/host/:slug*"
-    },
-    {
-      "source": "/documentation/serverless/logs",
-      "destination": "/guides/serverless/logging"
     },
     {
       "source": "/documentation/serverless/worker-list",
@@ -1624,14 +1604,6 @@
       "destination": "/guides/serverless/quickstart"
     },
     {
-      "source": "/documentation/serverless/endpoint-scaling-parameters",
-      "destination": "/guides/serverless/serverless-parameters"
-    },
-    {
-      "source": "/documentation/serverless/worker-py",
-      "destination": "/guides/serverless/creating-new-pyworkers"
-    },
-    {
       "source": "/documentation/teams/transfer-team-ownership",
       "destination": "/guides/teams/managing-teams"
     },
@@ -1642,22 +1614,6 @@
     {
       "source": "/documentation/:slug*",
       "destination": "/guides/:slug*"
-    },
-    {
-      "source": "/api/update-autogroup.md",
-      "destination": "/api-reference/serverless/update-workergroup"
-    },
-    {
-      "source": "/api/delete-autogroup.md",
-      "destination": "/api-reference/serverless/delete-workergroup"
-    },
-    {
-      "source": "/api/show-endpoints.md",
-      "destination": "/api-reference/serverless/show-endpoints"
-    },
-    {
-      "source": "/api/update-endpoint.md",
-      "destination": "/api-reference/serverless/update-endpoint"
     }
   ],
   "seo": {
@@ -1705,7 +1661,7 @@
       "attributes": {
         "type": "application/ld+json"
       },
-      "content": "{\"@context\":\"https://schema.org\",\"@type\":\"TechArticle\",\"headline\":\"Vast.ai Documentation \u2013 Affordable GPU Cloud Marketplace\",\"description\":\"Comprehensive documentation for Vast.ai GPU cloud computing platform including guides, API reference, and tutorials\",\"author\":{\"@type\":\"Organization\",\"name\":\"Vast.ai Team\"},\"publisher\":{\"@type\":\"Organization\",\"name\":\"Vast.ai\",\"logo\":{\"@type\":\"ImageObject\",\"url\":\"https://docs.vast.ai/logo/light.svg\"}},\"dateModified\":\"2025-09-25\",\"datePublished\":\"2024-01-01\",\"mainEntityOfPage\":{\"@type\":\"WebPage\",\"@id\":\"https://docs.vast.ai\"},\"articleSection\":\"Documentation\",\"keywords\":[\"GPU cloud\",\"AI training\",\"machine learning\",\"cloud computing\",\"documentation\",\"API\"]}"
+      "content": "{\"@context\":\"https://schema.org\",\"@type\":\"TechArticle\",\"headline\":\"Vast.ai Documentation: Affordable GPU Cloud Marketplace\",\"description\":\"Comprehensive documentation for Vast.ai GPU cloud computing platform including guides, API reference, and tutorials\",\"author\":{\"@type\":\"Organization\",\"name\":\"Vast.ai Team\"},\"publisher\":{\"@type\":\"Organization\",\"name\":\"Vast.ai\",\"logo\":{\"@type\":\"ImageObject\",\"url\":\"https://docs.vast.ai/logo/light.svg\"}},\"dateModified\":\"2025-09-25\",\"datePublished\":\"2024-01-01\",\"mainEntityOfPage\":{\"@type\":\"WebPage\",\"@id\":\"https://docs.vast.ai\"},\"articleSection\":\"Documentation\",\"keywords\":[\"GPU cloud\",\"AI training\",\"machine learning\",\"cloud computing\",\"documentation\",\"API\"]}"
     }
   ]
 }

--- a/examples/ai-agents/openclaw.mdx
+++ b/examples/ai-agents/openclaw.mdx
@@ -28,7 +28,7 @@ This gives you a private AI assistant powered by your own GPU instance, no API k
 - A terminal with `curl` available
 
 <Warning>
-  This guide creates a paid GPU instance that bills by the hour. An RTX 3090 typically costs $0.15-0.20/hr, following this guide end-to-end takes about 10 minutes and costs less than $0.05. Remember to destroy the instance when you're done, see [Cleanup](#cleanup).
+  This guide creates a paid GPU instance that bills by the hour. An RTX 3090 typically costs \$0.15-0.20/hr, following this guide end-to-end takes about 10 minutes and costs less than \$0.05. Remember to destroy the instance when you're done, see [Cleanup](#cleanup).
 </Warning>
 
 ## Step 1: Install the Vast.ai CLI

--- a/examples/ai-agents/overnight-ralph-loop.mdx
+++ b/examples/ai-agents/overnight-ralph-loop.mdx
@@ -287,7 +287,7 @@ ls -la *.py
 python -m pytest test_*.py -v
 ```
 
-**Cost estimate:** At ~$1.50/hr, an 8-12 hour overnight run costs $12-18.
+**Cost estimate:** At ~\$1.50/hr, an 8-12 hour overnight run costs \$12-18.
 
 **Tips:**
 - Use `tmux` or `screen` instead of `nohup` if you want to reattach later

--- a/guides/instances/choosing/reserved-instances.mdx
+++ b/guides/instances/choosing/reserved-instances.mdx
@@ -99,10 +99,10 @@ You can cancel (destroy) a reserved / prepaid instance to get part of your depos
 
 **Example:**
 
-- On-demand: $1/hr → $720/month
+- On-demand: \$1/hr → \$720/month
 - Reserved (1 month): \$576/month
 - Cancel immediately → Refund = \$576
-- Cancel after 15 days → Remaining = $288 → Refund = $216 (after discount penalty)
+- Cancel after 15 days → Remaining = \$288 → Refund = \$216 (after discount penalty)
 - Cancel at the end → Refund = \$0
 
 You will see the refund on the Billing page -\> Invoices table.

--- a/guides/instances/storage/cloud-backups.mdx
+++ b/guides/instances/storage/cloud-backups.mdx
@@ -15,7 +15,7 @@ This guide walks you through setting up and running automated backups for your V
 - A Vast.ai account
 - Access to a Vast.ai Docker-based instance
 - [Cloud storage connection set up in Vast.ai](/guides/instances/cloud-sync)
-- [(Optional) Install and use vast-cli](/cli/get-started)
+- [(Optional) Install and use vast-cli](/cli/hello-world)
 - [(Optional) Understanding of how to use cron in computers with Unix-like OS](https://cronitor.io/guides/cron-jobs)
 
 ## Setup

--- a/guides/reference/referral-program.mdx
+++ b/guides/reference/referral-program.mdx
@@ -23,7 +23,7 @@ Better yet, you can cash out **75% of those referral credits** via **Stripe Conn
 4. **Cash Out or Spend** - Use credits on Vast, or withdraw up to 75% as cash.
 
 <Note>
-If someone spends $1,000 over time, you get $30 in referral credits, forever.
+If someone spends \$1,000 over time, you get \$30 in referral credits, forever.
 </Note>
 
 ## Payout Rules, Important!
@@ -38,9 +38,9 @@ It keeps your referral earnings clear and makes sure you’re payout-eligible.
 
 <Warning>
   **Example:**
-  - You’ve earned $300 in referral credits.
-  - Lifetime charges on your account: $855.
-  - Since $300 < $855, you can't cash out until referral earnings exceed $855.
+  - You’ve earned \$300 in referral credits.
+  - Lifetime charges on your account: \$855.
+  - Since \$300 < \$855, you can't cash out until referral earnings exceed \$855.
 </Warning>
 
 ## Getting Your Referral Link

--- a/guides/serverless/comfy-ui.mdx
+++ b/guides/serverless/comfy-ui.mdx
@@ -84,7 +84,7 @@ If no custom benchmark is provided, the template uses Stable Diffusion v1.5 with
 
 # Endpoints
 
-The ComfyUI template provides endpoints for executing workflows and generating images. After obtaining a worker address from the `/route/` endpoint (see [route documentation](/guides/serverless/route)), you can send requests to the following endpoints.
+The ComfyUI template provides endpoints for executing workflows and generating images. After obtaining a worker address from the `/route/` endpoint (see [route documentation](/guides/serverless/architecture)), you can send requests to the following endpoints.
 
 ## /generate/sync
 

--- a/guides/serverless/comfyui-acestep.mdx
+++ b/guides/serverless/comfyui-acestep.mdx
@@ -104,7 +104,7 @@ The benchmarking system calculates a performance score for each worker that dete
 
 # Endpoints
 
-The ComfyUI ACE Step template provides endpoints for executing workflows and generating music. After obtaining a worker address from the `/route/` endpoint (see [route documentation](/guides/serverless/route)), you can send requests to the following endpoints.
+The ComfyUI ACE Step template provides endpoints for executing workflows and generating music. After obtaining a worker address from the `/route/` endpoint (see [route documentation](/guides/serverless/architecture)), you can send requests to the following endpoints.
 
 ## /generate/sync
 

--- a/guides/serverless/comfyui-wan-2.2.mdx
+++ b/guides/serverless/comfyui-wan-2.2.mdx
@@ -110,7 +110,7 @@ The benchmarking system calculates a performance score for each worker that dete
 
 # Endpoints
 
-The ComfyUI Wan 2.2 template provides endpoints for executing workflows and generating videos. After obtaining a worker address from the `/route/` endpoint (see [route documentation](/guides/serverless/route)), you can send requests to the following endpoints.
+The ComfyUI Wan 2.2 template provides endpoints for executing workflows and generating videos. After obtaining a worker address from the `/route/` endpoint (see [route documentation](/guides/serverless/architecture)), you can send requests to the following endpoints.
 
 ## /generate/sync
 

--- a/snippets/host/cli/list-machine.mdx
+++ b/snippets/host/cli/list-machine.mdx
@@ -21,7 +21,7 @@ vastai list machine ID [options]
 </ParamField>
 
 <ParamField path="-s" type="number">
-  storage price in $/GB/month (price for inactive instances), default: $0.10/GB/month (alias: `--price_disk`)
+  storage price in \$/GB/month (price for inactive instances), default: \$0.10/GB/month (alias: `--price_disk`)
 </ParamField>
 
 <ParamField path="-u" type="number">

--- a/snippets/host/cli/list-machines.mdx
+++ b/snippets/host/cli/list-machines.mdx
@@ -21,7 +21,7 @@ vastai list machines IDs [options]
 </ParamField>
 
 <ParamField path="-s" type="number">
-  storage price in $/GB/month (price for inactive instances), default: $0.10/GB/month (alias: `--price_disk`)
+  storage price in \$/GB/month (price for inactive instances), default: \$0.10/GB/month (alias: `--price_disk`)
 </ParamField>
 
 <ParamField path="-u" type="number">


### PR DESCRIPTION
## Summary

Cleanup pass on the docs site after the recent restructure, plus a README and SEO fix.

### Redirects

- Adds 4 redirects for legacy `.md` API URLs that were still returning real 404s in production:
  - `/api/update-autogroup.md` → `/api-reference/serverless/update-workergroup`
  - `/api/delete-autogroup.md` → `/api-reference/serverless/delete-workergroup`
  - `/api/show-endpoints.md` → `/api-reference/serverless/show-endpoints`
  - `/api/update-endpoint.md` → `/api-reference/serverless/update-endpoint`

- Changes the `/api/:slug*` catch-all destination from `/api-reference/:slug*` to `/api-reference/introduction`. The 1:1 mapping was producing 404s for any legacy URL whose slug doesn't exist verbatim in the new structure (most of them). Sending unknown `/api/...` traffic to the intro page preserves link equity instead of dumping it into a 404.

### Stale internal links

Updates links in 4 `.mdx` files that still pointed at pre restructure URLs:
- `/cli/get-started` → `/cli/hello-world`
- `/guides/serverless/route` → `/guides/serverless/architecture` (in the three ComfyUI templates)

These already worked via redirect, but cleaning them at the source means we can eventually retire those redirects.

### README

When googling this repo, the search snippet is being pulled from the README's H1 + first paragraph:

> Vast.ai Docs: Pages. This directory contains the docs pages shown at docs.vast.ai...

Rewrote it to be useful for the snippet instead of an internal note:

> **Vast.ai Documentation**
> Source for docs.vast.ai, the official documentation for the Vast.ai GPU cloud marketplace. Covers renting or hosting GPU instances, deploying serverless inference workloads, and using the CLI, SDK, and REST API.

### Cleanup

Removed the `refresh: 30` entry from `seo.metatags`. Mintlify renders it as `<meta name="refresh" content="30">` which is a no-op. Auto refresh only fires from `<meta http-equiv="refresh">`, and `name="refresh"` is not in the HTML spec's recognized name list, so all browsers and crawlers ignore it.
