### PR TITLE
Update host verification internet speed requirement to VRAM-scaled formula

### DIFF
--- a/host/verification-stages.mdx
+++ b/host/verification-stages.mdx
@@ -76,8 +76,8 @@ In order for your unverified machine to be verified, it must also meet the follo
 - CUDA version greater than or equal to 12.0
 - Reliability of 90%
 - At least 3 open ports per GPU (100 recommended)
-- Internet download speed of 500 Mb/s
-- Internet upload speed of 500 Mb/s
+- Internet Download speed must scale with total machine VRAM at ~2.6 Mbps per GiB, with a 100 Mbps floor and 500 Mbps ceiling
+- Internet Upload speed must scale with total machine VRAM at ~2.6 Mbps per GiB, with a 100 Mbps floor and 500 Mbps ceiling
 - GPU RAM of 7 GB
 - Passing the Self-Test
 ```


### PR DESCRIPTION
## Summary

- Updates `host/verification-stages.mdx` to replace the flat 500 Mb/s internet speed requirement with the actual dynamic formula: ~2.6 Mbps per GiB of total VRAM, floored at 100 Mbps, capped at 500 Mbps
- Fixes `docs.json` FAQ link to use absolute URL

## Details

The self-test code in `vast-cli` (`vastai/cli/util.py`) computes the required bandwidth as:

```
min(500, max(100, 500 × total_vram_gib / 192))
```

Example thresholds by GPU config:
| GPU | Total VRAM | Required speed |
|-----|-----------|----------------|
| A6000 (1×48 GiB) | 48 GiB | ~125 Mb/s |
| H100 (1×80 GiB) | 80 GiB | ~208 Mb/s |
| H200 (1×141 GiB) | 141 GiB | ~367 Mb/s |
| B200 (1×192 GiB) | 192 GiB | 500 Mb/s (cap) |

The same threshold applies to both upload and download.

## Test plan
- [ ] Verify page renders correctly at docs.vast.ai/host/verification-stages
- [ ] Confirm the formula description is accurate against `vastai/cli/util.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)