### PR TITLE
Add docs for market metric and start/stop deployment

### DIFF
--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -4644,27 +4644,51 @@ paths:
                         available:
                           type: integer
                           description: Available machines
+                        rented_verified:
+                          type: integer
+                          description: Rented verified machines
+                        avail_verified:
+                          type: integer
+                          description: Available verified machines
+                        rented_unverified:
+                          type: integer
+                          description: Rented unverified machines
+                        avail_unverified:
+                          type: integer
+                          description: Available unverified machines
                         usage:
                           type: number
-                          description: Current utilization ratio
-                        price_median:
+                          description: Current utilization percentage
+                        usage_30d:
                           type: number
-                          description: Median rental price per GPU per hour
-                        price_p10:
-                          type: number
-                          description: 10th percentile price
-                        price_p90:
-                          type: number
-                          description: 90th percentile price
-                        tflops:
-                          type: number
-                          description: GPU TFLOPS rating
+                          description: 30-day average utilization percentage
                         dlperf:
                           type: number
                           description: Deep learning performance score
+                        tflops:
+                          type: number
+                          description: GPU TFLOPS rating
+                        price_p10:
+                          type: number
+                          description: 10th percentile price per GPU per hour
+                        price_p25:
+                          type: number
+                          description: 25th percentile price
+                        price_median:
+                          type: number
+                          description: Median price per GPU per hour
+                        price_p75:
+                          type: number
+                          description: 75th percentile price
+                        price_p90:
+                          type: number
+                          description: 90th percentile price
                         tflops_per_dollar:
                           type: number
                           description: TFLOPS per dollar
+                        dlperf_per_dollar:
+                          type: number
+                          description: Deep learning performance per dollar
         '401':
           description: Unauthorized
           content:
@@ -4826,78 +4850,131 @@ paths:
             application/json:
               schema:
                 type: object
-                description: Keyed by GPU name. Each GPU contains stats and a time-series
-                  rows array.
-                additionalProperties:
-                  type: object
-                  properties:
-                    stats:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  gpus:
+                    type: object
+                    description: Keyed by GPU name
+                    additionalProperties:
                       type: object
                       properties:
-                        tflops:
-                          type: number
-                          example: 82.6
-                        dlperf:
-                          type: number
-                          example: 97.5
-                        tflops_per_dollar:
-                          type: number
-                          example: 127.1
-                        dlperf_per_dollar:
-                          type: number
-                          example: 150.0
-                    rows:
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          date:
-                            type: string
-                            description: Human-readable UTC date
-                            example: '2026-05-25 19:08:36'
-                          timestamp:
-                            type: integer
-                            description: Unix timestamp
-                            example: 1779736116
-                          rented_verified:
-                            type: integer
-                            example: 3804
-                          avail_verified:
-                            type: integer
-                            example: 150
-                          rented_unverified:
-                            type: integer
-                            example: 383
-                          avail_unverified:
-                            type: integer
-                            example: 109
-                          total:
-                            type: integer
-                            example: 4446
-                          rented_p10:
-                            type: number
-                            description: 10th percentile rented price
-                            example: 0.246
-                          rented_median:
-                            type: number
-                            description: Median rented price
-                            example: 0.39
-                          rented_p90:
-                            type: number
-                            description: 90th percentile rented price
-                            example: 0.599
-                          avail_p10:
-                            type: number
-                            description: 10th percentile available price
-                            example: 0.25
-                          avail_median:
-                            type: number
-                            description: Median available price
-                            example: 0.5
-                          avail_p90:
-                            type: number
-                            description: 90th percentile available price
-                            example: 1.0
+                        supply_demand:
+                          type: object
+                          description: Time-series arrays of supply and demand counts
+                          properties:
+                            timestamps:
+                              type: array
+                              items:
+                                type: integer
+                              example:
+                              - 1779736460
+                              - 1779736632
+                            rented_verified:
+                              type: array
+                              items:
+                                type: integer
+                              example:
+                              - 3789
+                              - 3756
+                            avail_verified:
+                              type: array
+                              items:
+                                type: integer
+                              example:
+                              - 165
+                              - 200
+                            rented_unverified:
+                              type: array
+                              items:
+                                type: integer
+                              example:
+                              - 385
+                              - 390
+                            avail_unverified:
+                              type: array
+                              items:
+                                type: integer
+                              example:
+                              - 107
+                              - 100
+                            total:
+                              type: array
+                              items:
+                                type: integer
+                              example:
+                              - 4446
+                              - 4446
+                        pricing:
+                          type: object
+                          description: Time-series arrays of pricing percentiles
+                          properties:
+                            timestamps:
+                              type: array
+                              items:
+                                type: integer
+                              example:
+                              - 1779736460
+                              - 1779736632
+                            rented_p10:
+                              type: array
+                              items:
+                                type: number
+                              example:
+                              - 0.246
+                              - 0.246
+                            rented_median:
+                              type: array
+                              items:
+                                type: number
+                              example:
+                              - 0.39
+                              - 0.38
+                            rented_p90:
+                              type: array
+                              items:
+                                type: number
+                              example:
+                              - 0.599
+                              - 0.55
+                            avail_p10:
+                              type: array
+                              items:
+                                type: number
+                              example:
+                              - 0.254
+                              - 0.289
+                            avail_median:
+                              type: array
+                              items:
+                                type: number
+                              example:
+                              - 0.5
+                              - 0.5
+                            avail_p90:
+                              type: array
+                              items:
+                                type: number
+                              example:
+                              - 0.973
+                              - 0.85
+                        stats:
+                          type: object
+                          description: Static performance metrics for this GPU
+                          properties:
+                            tflops:
+                              type: number
+                              example: 82.6
+                            dlperf:
+                              type: number
+                              example: 97.5
+                            tflops_per_dollar:
+                              type: number
+                              example: 127.1
+                            dlperf_per_dollar:
+                              type: number
+                              example: 150.0
         '401':
           description: Unauthorized
           content:
@@ -6808,6 +6885,10 @@ paths:
                         nullable: true
                         description: Current state of the endpoint
                         example: active
+                      env:
+                        type: string
+                        nullable: true
+                        description: Environment variables and port mappings
                       s3_key:
                         type: string
                         nullable: true
@@ -6816,6 +6897,10 @@ paths:
                         type: string
                         nullable: true
                         description: Content hash of the deployed code
+                      search_params:
+                        type: string
+                        nullable: true
+                        description: Search query for instance selection
                       current_version_id:
                         type: integer
                         nullable: true
@@ -6828,6 +6913,10 @@ paths:
                       ttl:
                         type: number
                         nullable: true
+                      last_client_heartbeat:
+                        type: number
+                        nullable: true
+                        description: Unix timestamp of last client heartbeat
                       created_at:
                         type: number
                         description: Unix timestamp
@@ -6899,10 +6988,22 @@ paths:
                           type: integer
                           nullable: true
                           example: 25121
+                        env:
+                          type: string
+                          nullable: true
+                          description: Environment variables and port mappings
                         file_hash:
                           type: string
                           nullable: true
                           description: Content hash of the deployed code
+                        s3_key:
+                          type: string
+                          nullable: true
+                          description: S3 object key for the current code version
+                        search_params:
+                          type: string
+                          nullable: true
+                          description: Search query for instance selection
                         current_version_id:
                           type: integer
                           nullable: true
@@ -6915,6 +7016,10 @@ paths:
                         ttl:
                           type: number
                           nullable: true
+                        last_client_heartbeat:
+                          type: number
+                          nullable: true
+                          description: Unix timestamp of last client heartbeat
                         created_at:
                           type: number
                           description: Unix timestamp

--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -4578,6 +4578,344 @@ paths:
                     example: Not authorized to view logs for this instance
       tags:
       - Instances
+  /api/v0/metrics/gpu/current/:
+    get:
+      summary: show gpu metrics
+      description: 'Returns a current snapshot of supply, demand, and pricing across
+        all GPU types on the Vast marketplace. Use filters to narrow results to verified
+        or datacenter machines.
+
+
+        CLI Usage: `vastai metrics gpu [options]`'
+      security:
+      - BearerAuth: []
+      parameters:
+      - name: verified
+        in: query
+        required: false
+        description: Filter by verification status
+        schema:
+          type: string
+          enum:
+          - 'yes'
+          - 'no'
+          - all
+          default: 'yes'
+      - name: hosting_type
+        in: query
+        required: false
+        description: Filter by hosting type
+        schema:
+          type: string
+          enum:
+          - all
+          - secure_cloud
+          - community
+          default: all
+      - name: num_gpus
+        in: query
+        required: false
+        description: GPU count bucket or "all" for true population
+        schema:
+          type: string
+          default: all
+      responses:
+        '200':
+          description: Success response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  gpus:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        gpu_name:
+                          type: string
+                          example: RTX 4090
+                        total:
+                          type: integer
+                          description: Total number of machines
+                        available:
+                          type: integer
+                          description: Available machines
+                        usage:
+                          type: number
+                          description: Current utilization ratio
+                        price_median:
+                          type: number
+                          description: Median rental price per GPU per hour
+                        price_p10:
+                          type: number
+                          description: 10th percentile price
+                        price_p90:
+                          type: number
+                          description: 90th percentile price
+                        tflops:
+                          type: number
+                          description: GPU TFLOPS rating
+                        dlperf:
+                          type: number
+                          description: Deep learning performance score
+                        tflops_per_dollar:
+                          type: number
+                          description: TFLOPS per dollar
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Too Many Requests
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: API requests too frequent endpoint threshold=3.0
+      tags:
+      - Machines
+  /api/v0/metrics/gpu/locations/:
+    get:
+      summary: show gpu locations
+      description: 'Returns the geographic distribution of GPUs across the Vast marketplace.
+        The CLI supports client-side filtering by GPU type, verification, datacenter,
+        and rental status.
+
+
+        CLI Usage: `vastai metrics gpu-locations [options]`'
+      security:
+      - BearerAuth: []
+      responses:
+        '200':
+          description: Success response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  locations:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        latitude:
+                          type: number
+                          example: 37.7749
+                        longitude:
+                          type: number
+                          example: -122.4194
+                        city:
+                          type: string
+                          example: San Francisco
+                        country_code:
+                          type: string
+                          example: US
+                        gpu_name:
+                          type: string
+                          example: RTX 4090
+                        rented:
+                          type: boolean
+                        verified:
+                          type: boolean
+                        datacenter:
+                          type: boolean
+                        num_gpus:
+                          type: integer
+                          example: 4
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Too Many Requests
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: API requests too frequent endpoint threshold=3.0
+      tags:
+      - Machines
+  /api/v0/metrics/gpu/history/:
+    get:
+      summary: show gpu trends
+      description: 'Returns time-series data for GPU supply, demand, and pricing.
+        By default queries the last 24 hours and returns a sampled set of roughly
+        20 data points. Use start/end/step for custom time ranges.
+
+
+        CLI Usage: `vastai metrics gpu-trends [GPU_NAMES] [options]`'
+      security:
+      - BearerAuth: []
+      parameters:
+      - name: gpu_name
+        in: query
+        required: false
+        description: Comma-separated GPU names (e.g. "RTX 4090, H100_SXM") or "all".
+          Defaults to RTX 5090, 4090, and 3090.
+        schema:
+          type: string
+          example: RTX 4090
+      - name: verified
+        in: query
+        required: false
+        description: Filter by verification status
+        schema:
+          type: string
+          enum:
+          - 'yes'
+          - 'no'
+          - all
+          default: 'yes'
+      - name: hosting_type
+        in: query
+        required: false
+        description: Filter by hosting type
+        schema:
+          type: string
+          enum:
+          - all
+          - secure_cloud
+          - community
+          default: all
+      - name: num_gpus
+        in: query
+        required: false
+        description: GPU count bucket or "all"
+        schema:
+          type: string
+          default: all
+      - name: start
+        in: query
+        required: false
+        description: Unix timestamp for range start
+        schema:
+          type: integer
+      - name: end
+        in: query
+        required: false
+        description: Unix timestamp for range end
+        schema:
+          type: integer
+      - name: step
+        in: query
+        required: false
+        description: Seconds between data points (e.g. 3600 for hourly)
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: Success response
+          content:
+            application/json:
+              schema:
+                type: object
+                description: Keyed by GPU name. Each GPU contains stats and a time-series
+                  rows array.
+                additionalProperties:
+                  type: object
+                  properties:
+                    stats:
+                      type: object
+                      properties:
+                        tflops:
+                          type: number
+                          example: 82.6
+                        dlperf:
+                          type: number
+                          example: 97.5
+                        tflops_per_dollar:
+                          type: number
+                          example: 127.1
+                        dlperf_per_dollar:
+                          type: number
+                          example: 150.0
+                    rows:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          date:
+                            type: string
+                            description: Human-readable UTC date
+                            example: '2026-05-25 19:08:36'
+                          timestamp:
+                            type: integer
+                            description: Unix timestamp
+                            example: 1779736116
+                          rented_verified:
+                            type: integer
+                            example: 3804
+                          avail_verified:
+                            type: integer
+                            example: 150
+                          rented_unverified:
+                            type: integer
+                            example: 383
+                          avail_unverified:
+                            type: integer
+                            example: 109
+                          total:
+                            type: integer
+                            example: 4446
+                          rented_p10:
+                            type: number
+                            description: 10th percentile rented price
+                            example: 0.246
+                          rented_median:
+                            type: number
+                            description: Median rented price
+                            example: 0.39
+                          rented_p90:
+                            type: number
+                            description: 90th percentile rented price
+                            example: 0.599
+                          avail_p10:
+                            type: number
+                            description: 10th percentile available price
+                            example: 0.25
+                          avail_median:
+                            type: number
+                            description: Median available price
+                            example: 0.5
+                          avail_p90:
+                            type: number
+                            description: 90th percentile available price
+                            example: 1.0
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Too Many Requests
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: API requests too frequent endpoint threshold=3.0
+      tags:
+      - Machines
   /api/v0/instances/prepay/{id}/:
     put:
       summary: prepay instance
@@ -6417,6 +6755,190 @@ paths:
                     example: API requests too frequent endpoint threshold=2.9
       tags:
       - Accounts
+  /api/v0/deployment/{id}/:
+    get:
+      summary: show deployment
+      description: 'Returns detailed information about a single deployment, including
+        endpoint state and worker count.
+
+
+        CLI Usage: `vastai show deployment <id>`'
+      security:
+      - BearerAuth: []
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Deployment ID
+        example: 644
+      responses:
+        '200':
+          description: Deployment details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  deployment:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        example: 644
+                      name:
+                        type: string
+                        example: square
+                      tag:
+                        type: string
+                        example: default
+                      image:
+                        type: string
+                        example: vastai/base-image:latest
+                      endpoint_id:
+                        type: integer
+                        nullable: true
+                        example: 25121
+                      endpoint_state:
+                        type: string
+                        nullable: true
+                        description: Current state of the endpoint
+                        example: active
+                      s3_key:
+                        type: string
+                        nullable: true
+                        description: S3 object key for the current code version
+                      file_hash:
+                        type: string
+                        nullable: true
+                        description: Content hash of the deployed code
+                      current_version_id:
+                        type: integer
+                        nullable: true
+                      last_healthy_version_id:
+                        type: integer
+                        nullable: true
+                      storage:
+                        type: number
+                        example: 16.0
+                      ttl:
+                        type: number
+                        nullable: true
+                      created_at:
+                        type: number
+                        description: Unix timestamp
+                      updated_at:
+                        type: number
+                        description: Unix timestamp
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Deployment not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Too Many Requests
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: API requests too frequent endpoint threshold=3.0
+      tags:
+      - Serverless
+  /api/v0/deployments/:
+    get:
+      summary: show deployments
+      description: 'Returns all deployments owned by the authenticated user.
+
+
+        CLI Usage: `vastai show deployments`'
+      security:
+      - BearerAuth: []
+      responses:
+        '200':
+          description: A list of deployments
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  deployments:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                          example: 644
+                        name:
+                          type: string
+                          example: square
+                        tag:
+                          type: string
+                          example: default
+                        image:
+                          type: string
+                          example: vastai/base-image:latest
+                        endpoint_id:
+                          type: integer
+                          nullable: true
+                          example: 25121
+                        file_hash:
+                          type: string
+                          nullable: true
+                          description: Content hash of the deployed code
+                        current_version_id:
+                          type: integer
+                          nullable: true
+                        last_healthy_version_id:
+                          type: integer
+                          nullable: true
+                        storage:
+                          type: number
+                          example: 16.0
+                        ttl:
+                          type: number
+                          nullable: true
+                        created_at:
+                          type: number
+                          description: Unix timestamp
+                        updated_at:
+                          type: number
+                          description: Unix timestamp
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Too Many Requests
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: API requests too frequent endpoint threshold=3.0
+      tags:
+      - Serverless
   /api/v0/instances/balance/{id}/:
     get:
       summary: show deposit
@@ -7837,6 +8359,118 @@ paths:
                 $ref: '#/components/schemas/Error'
       tags:
       - Accounts
+  /api/v0/deployment/{id}/start/:
+    post:
+      summary: start deployment
+      description: 'Starts (or restarts) the endpoint associated with a deployment.
+        The autoscaler will begin recruiting workers according to the scaling policy.
+
+
+        CLI Usage: `vastai start deployment <id>`'
+      security:
+      - BearerAuth: []
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Deployment ID
+        example: 644
+      responses:
+        '200':
+          description: Deployment started successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  endpoint_state:
+                    type: string
+                    example: active
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Deployment not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Too Many Requests
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: API requests too frequent endpoint threshold=2.0
+      tags:
+      - Serverless
+  /api/v0/deployment/{id}/stop/:
+    post:
+      summary: stop deployment
+      description: 'Stops the endpoint associated with a deployment. The deployment
+        is not deleted and can be restarted with the start deployment endpoint.
+
+
+        CLI Usage: `vastai stop deployment <id>`'
+      security:
+      - BearerAuth: []
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Deployment ID
+        example: 644
+      responses:
+        '200':
+          description: Deployment stopped successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  endpoint_state:
+                    type: string
+                    example: stopped
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Deployment not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Too Many Requests
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: API requests too frequent endpoint threshold=2.0
+      tags:
+      - Serverless
   /api/v0/commands/transfer_credit/:
     put:
       summary: transfer credit

--- a/api-reference/openapi/yaml/metrics_gpu.yaml
+++ b/api-reference/openapi/yaml/metrics_gpu.yaml
@@ -71,27 +71,51 @@ paths:
                         available:
                           type: integer
                           description: Available machines
+                        rented_verified:
+                          type: integer
+                          description: Rented verified machines
+                        avail_verified:
+                          type: integer
+                          description: Available verified machines
+                        rented_unverified:
+                          type: integer
+                          description: Rented unverified machines
+                        avail_unverified:
+                          type: integer
+                          description: Available unverified machines
                         usage:
                           type: number
-                          description: Current utilization ratio
-                        price_median:
+                          description: Current utilization percentage
+                        usage_30d:
                           type: number
-                          description: Median rental price per GPU per hour
-                        price_p10:
-                          type: number
-                          description: 10th percentile price
-                        price_p90:
-                          type: number
-                          description: 90th percentile price
-                        tflops:
-                          type: number
-                          description: GPU TFLOPS rating
+                          description: 30-day average utilization percentage
                         dlperf:
                           type: number
                           description: Deep learning performance score
+                        tflops:
+                          type: number
+                          description: GPU TFLOPS rating
+                        price_p10:
+                          type: number
+                          description: 10th percentile price per GPU per hour
+                        price_p25:
+                          type: number
+                          description: 25th percentile price
+                        price_median:
+                          type: number
+                          description: Median price per GPU per hour
+                        price_p75:
+                          type: number
+                          description: 75th percentile price
+                        price_p90:
+                          type: number
+                          description: 90th percentile price
                         tflops_per_dollar:
                           type: number
                           description: TFLOPS per dollar
+                        dlperf_per_dollar:
+                          type: number
+                          description: Deep learning performance per dollar
         '401':
           description: Unauthorized
           content:

--- a/api-reference/openapi/yaml/metrics_gpu.yaml
+++ b/api-reference/openapi/yaml/metrics_gpu.yaml
@@ -1,0 +1,139 @@
+openapi: 3.0.0
+info:
+  title: Metrics GPU API
+  description: Show current GPU market metrics
+  version: 1.0.0
+servers:
+- url: https://console.vast.ai
+  description: Production server
+paths:
+  /api/v0/metrics/gpu/current/:
+    get:
+      summary: show gpu metrics
+      description: |
+        Returns a current snapshot of supply, demand, and pricing across all GPU types on the Vast marketplace. Use filters to narrow results to verified or datacenter machines.
+
+        CLI Usage: `vastai metrics gpu [options]`
+      security:
+      - BearerAuth: []
+      parameters:
+      - name: verified
+        in: query
+        required: false
+        description: Filter by verification status
+        schema:
+          type: string
+          enum:
+          - 'yes'
+          - 'no'
+          - all
+          default: 'yes'
+      - name: hosting_type
+        in: query
+        required: false
+        description: Filter by hosting type
+        schema:
+          type: string
+          enum:
+          - all
+          - secure_cloud
+          - community
+          default: all
+      - name: num_gpus
+        in: query
+        required: false
+        description: GPU count bucket or "all" for true population
+        schema:
+          type: string
+          default: all
+      responses:
+        '200':
+          description: Success response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  gpus:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        gpu_name:
+                          type: string
+                          example: RTX 4090
+                        total:
+                          type: integer
+                          description: Total number of machines
+                        available:
+                          type: integer
+                          description: Available machines
+                        usage:
+                          type: number
+                          description: Current utilization ratio
+                        price_median:
+                          type: number
+                          description: Median rental price per GPU per hour
+                        price_p10:
+                          type: number
+                          description: 10th percentile price
+                        price_p90:
+                          type: number
+                          description: 90th percentile price
+                        tflops:
+                          type: number
+                          description: GPU TFLOPS rating
+                        dlperf:
+                          type: number
+                          description: Deep learning performance score
+                        tflops_per_dollar:
+                          type: number
+                          description: TFLOPS per dollar
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Too Many Requests
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: API requests too frequent endpoint threshold=3.0
+      tags:
+      - Machines
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      description: API key must be provided in the Authorization header
+  schemas:
+    Error:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: false
+        error:
+          type: string
+        msg:
+          type: string
+x-rate-limit:
+  threshold: 3.0
+  per: request
+  description: Maximum request frequency per IP address for this endpoint
+x-cli-commands:
+- name: metrics gpu
+  description: Show current GPU market metrics
+  endpoint: /api/v0/metrics/gpu/current/
+  method: GET
+  example: vastai metrics gpu

--- a/api-reference/openapi/yaml/metrics_gpu_locations.yaml
+++ b/api-reference/openapi/yaml/metrics_gpu_locations.yaml
@@ -1,0 +1,103 @@
+openapi: 3.0.0
+info:
+  title: Metrics GPU Locations API
+  description: Show geographic distribution of GPUs on the marketplace
+  version: 1.0.0
+servers:
+- url: https://console.vast.ai
+  description: Production server
+paths:
+  /api/v0/metrics/gpu/locations/:
+    get:
+      summary: show gpu locations
+      description: |
+        Returns the geographic distribution of GPUs across the Vast marketplace. The CLI supports client-side filtering by GPU type, verification, datacenter, and rental status.
+
+        CLI Usage: `vastai metrics gpu-locations [options]`
+      security:
+      - BearerAuth: []
+      responses:
+        '200':
+          description: Success response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  locations:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        latitude:
+                          type: number
+                          example: 37.7749
+                        longitude:
+                          type: number
+                          example: -122.4194
+                        city:
+                          type: string
+                          example: San Francisco
+                        country_code:
+                          type: string
+                          example: US
+                        gpu_name:
+                          type: string
+                          example: RTX 4090
+                        rented:
+                          type: boolean
+                        verified:
+                          type: boolean
+                        datacenter:
+                          type: boolean
+                        num_gpus:
+                          type: integer
+                          example: 4
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Too Many Requests
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: API requests too frequent endpoint threshold=3.0
+      tags:
+      - Machines
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      description: API key must be provided in the Authorization header
+  schemas:
+    Error:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: false
+        error:
+          type: string
+        msg:
+          type: string
+x-rate-limit:
+  threshold: 3.0
+  per: request
+  description: Maximum request frequency per IP address for this endpoint
+x-cli-commands:
+- name: metrics gpu-locations
+  description: Show GPU location metrics
+  endpoint: /api/v0/metrics/gpu/locations/
+  method: GET
+  example: vastai metrics gpu-locations

--- a/api-reference/openapi/yaml/metrics_gpu_trends.yaml
+++ b/api-reference/openapi/yaml/metrics_gpu_trends.yaml
@@ -1,0 +1,198 @@
+openapi: 3.0.0
+info:
+  title: Metrics GPU Trends API
+  description: Show historical GPU market trends
+  version: 1.0.0
+servers:
+- url: https://console.vast.ai
+  description: Production server
+paths:
+  /api/v0/metrics/gpu/history/:
+    get:
+      summary: show gpu trends
+      description: |
+        Returns time-series data for GPU supply, demand, and pricing. By default queries the last 24 hours and returns a sampled set of roughly 20 data points. Use start/end/step for custom time ranges.
+
+        CLI Usage: `vastai metrics gpu-trends [GPU_NAMES] [options]`
+      security:
+      - BearerAuth: []
+      parameters:
+      - name: gpu_name
+        in: query
+        required: false
+        description: Comma-separated GPU names (e.g. "RTX 4090, H100_SXM") or "all".
+          Defaults to RTX 5090, 4090, and 3090.
+        schema:
+          type: string
+          example: RTX 4090
+      - name: verified
+        in: query
+        required: false
+        description: Filter by verification status
+        schema:
+          type: string
+          enum:
+          - 'yes'
+          - 'no'
+          - all
+          default: 'yes'
+      - name: hosting_type
+        in: query
+        required: false
+        description: Filter by hosting type
+        schema:
+          type: string
+          enum:
+          - all
+          - secure_cloud
+          - community
+          default: all
+      - name: num_gpus
+        in: query
+        required: false
+        description: GPU count bucket or "all"
+        schema:
+          type: string
+          default: all
+      - name: start
+        in: query
+        required: false
+        description: Unix timestamp for range start
+        schema:
+          type: integer
+      - name: end
+        in: query
+        required: false
+        description: Unix timestamp for range end
+        schema:
+          type: integer
+      - name: step
+        in: query
+        required: false
+        description: Seconds between data points (e.g. 3600 for hourly)
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: Success response
+          content:
+            application/json:
+              schema:
+                type: object
+                description: Keyed by GPU name. Each GPU contains stats and a time-series
+                  rows array.
+                additionalProperties:
+                  type: object
+                  properties:
+                    stats:
+                      type: object
+                      properties:
+                        tflops:
+                          type: number
+                          example: 82.6
+                        dlperf:
+                          type: number
+                          example: 97.5
+                        tflops_per_dollar:
+                          type: number
+                          example: 127.1
+                        dlperf_per_dollar:
+                          type: number
+                          example: 150.0
+                    rows:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          date:
+                            type: string
+                            description: Human-readable UTC date
+                            example: '2026-05-25 19:08:36'
+                          timestamp:
+                            type: integer
+                            description: Unix timestamp
+                            example: 1779736116
+                          rented_verified:
+                            type: integer
+                            example: 3804
+                          avail_verified:
+                            type: integer
+                            example: 150
+                          rented_unverified:
+                            type: integer
+                            example: 383
+                          avail_unverified:
+                            type: integer
+                            example: 109
+                          total:
+                            type: integer
+                            example: 4446
+                          rented_p10:
+                            type: number
+                            description: 10th percentile rented price
+                            example: 0.246
+                          rented_median:
+                            type: number
+                            description: Median rented price
+                            example: 0.39
+                          rented_p90:
+                            type: number
+                            description: 90th percentile rented price
+                            example: 0.599
+                          avail_p10:
+                            type: number
+                            description: 10th percentile available price
+                            example: 0.25
+                          avail_median:
+                            type: number
+                            description: Median available price
+                            example: 0.5
+                          avail_p90:
+                            type: number
+                            description: 90th percentile available price
+                            example: 1.0
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Too Many Requests
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: API requests too frequent endpoint threshold=3.0
+      tags:
+      - Machines
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      description: API key must be provided in the Authorization header
+  schemas:
+    Error:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: false
+        error:
+          type: string
+        msg:
+          type: string
+x-rate-limit:
+  threshold: 3.0
+  per: request
+  description: Maximum request frequency per IP address for this endpoint
+x-cli-commands:
+- name: metrics gpu-trends
+  description: Show GPU market trends
+  endpoint: /api/v0/metrics/gpu/history/
+  method: GET
+  example: vastai metrics gpu-trends "RTX 4090"

--- a/api-reference/openapi/yaml/metrics_gpu_trends.yaml
+++ b/api-reference/openapi/yaml/metrics_gpu_trends.yaml
@@ -79,78 +79,105 @@ paths:
             application/json:
               schema:
                 type: object
-                description: Keyed by GPU name. Each GPU contains stats and a time-series
-                  rows array.
-                additionalProperties:
-                  type: object
-                  properties:
-                    stats:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  gpus:
+                    type: object
+                    description: Keyed by GPU name
+                    additionalProperties:
                       type: object
                       properties:
-                        tflops:
-                          type: number
-                          example: 82.6
-                        dlperf:
-                          type: number
-                          example: 97.5
-                        tflops_per_dollar:
-                          type: number
-                          example: 127.1
-                        dlperf_per_dollar:
-                          type: number
-                          example: 150.0
-                    rows:
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          date:
-                            type: string
-                            description: Human-readable UTC date
-                            example: '2026-05-25 19:08:36'
-                          timestamp:
-                            type: integer
-                            description: Unix timestamp
-                            example: 1779736116
-                          rented_verified:
-                            type: integer
-                            example: 3804
-                          avail_verified:
-                            type: integer
-                            example: 150
-                          rented_unverified:
-                            type: integer
-                            example: 383
-                          avail_unverified:
-                            type: integer
-                            example: 109
-                          total:
-                            type: integer
-                            example: 4446
-                          rented_p10:
-                            type: number
-                            description: 10th percentile rented price
-                            example: 0.246
-                          rented_median:
-                            type: number
-                            description: Median rented price
-                            example: 0.39
-                          rented_p90:
-                            type: number
-                            description: 90th percentile rented price
-                            example: 0.599
-                          avail_p10:
-                            type: number
-                            description: 10th percentile available price
-                            example: 0.25
-                          avail_median:
-                            type: number
-                            description: Median available price
-                            example: 0.5
-                          avail_p90:
-                            type: number
-                            description: 90th percentile available price
-                            example: 1.0
+                        supply_demand:
+                          type: object
+                          description: Time-series arrays of supply and demand counts
+                          properties:
+                            timestamps:
+                              type: array
+                              items:
+                                type: integer
+                              example: [1779736460, 1779736632]
+                            rented_verified:
+                              type: array
+                              items:
+                                type: integer
+                              example: [3789, 3756]
+                            avail_verified:
+                              type: array
+                              items:
+                                type: integer
+                              example: [165, 200]
+                            rented_unverified:
+                              type: array
+                              items:
+                                type: integer
+                              example: [385, 390]
+                            avail_unverified:
+                              type: array
+                              items:
+                                type: integer
+                              example: [107, 100]
+                            total:
+                              type: array
+                              items:
+                                type: integer
+                              example: [4446, 4446]
+                        pricing:
+                          type: object
+                          description: Time-series arrays of pricing percentiles
+                          properties:
+                            timestamps:
+                              type: array
+                              items:
+                                type: integer
+                              example: [1779736460, 1779736632]
+                            rented_p10:
+                              type: array
+                              items:
+                                type: number
+                              example: [0.246, 0.246]
+                            rented_median:
+                              type: array
+                              items:
+                                type: number
+                              example: [0.39, 0.38]
+                            rented_p90:
+                              type: array
+                              items:
+                                type: number
+                              example: [0.599, 0.55]
+                            avail_p10:
+                              type: array
+                              items:
+                                type: number
+                              example: [0.254, 0.289]
+                            avail_median:
+                              type: array
+                              items:
+                                type: number
+                              example: [0.5, 0.5]
+                            avail_p90:
+                              type: array
+                              items:
+                                type: number
+                              example: [0.973, 0.85]
+                        stats:
+                          type: object
+                          description: Static performance metrics for this GPU
+                          properties:
+                            tflops:
+                              type: number
+                              example: 82.6
+                            dlperf:
+                              type: number
+                              example: 97.5
+                            tflops_per_dollar:
+                              type: number
+                              example: 127.1
+                            dlperf_per_dollar:
+                              type: number
+                              example: 150.0
         '401':
           description: Unauthorized
           content:

--- a/api-reference/openapi/yaml/show_deployment.yaml
+++ b/api-reference/openapi/yaml/show_deployment.yaml
@@ -1,0 +1,138 @@
+openapi: 3.0.0
+info:
+  title: Show Deployment API
+  description: Retrieve details of a single deployment
+  version: 1.0.0
+servers:
+- url: https://console.vast.ai
+  description: Production server
+paths:
+  /api/v0/deployment/{id}/:
+    get:
+      summary: show deployment
+      description: |
+        Returns detailed information about a single deployment, including endpoint state and worker count.
+
+        CLI Usage: `vastai show deployment <id>`
+      security:
+      - BearerAuth: []
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Deployment ID
+        example: 644
+      responses:
+        '200':
+          description: Deployment details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  deployment:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        example: 644
+                      name:
+                        type: string
+                        example: square
+                      tag:
+                        type: string
+                        example: default
+                      image:
+                        type: string
+                        example: vastai/base-image:latest
+                      endpoint_id:
+                        type: integer
+                        nullable: true
+                        example: 25121
+                      endpoint_state:
+                        type: string
+                        nullable: true
+                        description: Current state of the endpoint
+                        example: active
+                      s3_key:
+                        type: string
+                        nullable: true
+                        description: S3 object key for the current code version
+                      file_hash:
+                        type: string
+                        nullable: true
+                        description: Content hash of the deployed code
+                      current_version_id:
+                        type: integer
+                        nullable: true
+                      last_healthy_version_id:
+                        type: integer
+                        nullable: true
+                      storage:
+                        type: number
+                        example: 16.0
+                      ttl:
+                        type: number
+                        nullable: true
+                      created_at:
+                        type: number
+                        description: Unix timestamp
+                      updated_at:
+                        type: number
+                        description: Unix timestamp
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Deployment not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Too Many Requests
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: API requests too frequent endpoint threshold=3.0
+      tags:
+      - Serverless
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      description: API key must be provided in the Authorization header
+  schemas:
+    Error:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: false
+        error:
+          type: string
+        msg:
+          type: string
+x-rate-limit:
+  threshold: 3.0
+  per: request
+  description: Maximum request frequency per IP address for this endpoint
+x-cli-commands:
+- name: show deployment
+  description: Display a single deployment
+  endpoint: /api/v0/deployment/{id}/
+  method: GET
+  example: vastai show deployment 644

--- a/api-reference/openapi/yaml/show_deployment.yaml
+++ b/api-reference/openapi/yaml/show_deployment.yaml
@@ -59,6 +59,10 @@ paths:
                         nullable: true
                         description: Current state of the endpoint
                         example: active
+                      env:
+                        type: string
+                        nullable: true
+                        description: Environment variables and port mappings
                       s3_key:
                         type: string
                         nullable: true
@@ -67,6 +71,10 @@ paths:
                         type: string
                         nullable: true
                         description: Content hash of the deployed code
+                      search_params:
+                        type: string
+                        nullable: true
+                        description: Search query for instance selection
                       current_version_id:
                         type: integer
                         nullable: true
@@ -79,6 +87,10 @@ paths:
                       ttl:
                         type: number
                         nullable: true
+                      last_client_heartbeat:
+                        type: number
+                        nullable: true
+                        description: Unix timestamp of last client heartbeat
                       created_at:
                         type: number
                         description: Unix timestamp

--- a/api-reference/openapi/yaml/show_deployments.yaml
+++ b/api-reference/openapi/yaml/show_deployments.yaml
@@ -48,10 +48,22 @@ paths:
                           type: integer
                           nullable: true
                           example: 25121
+                        env:
+                          type: string
+                          nullable: true
+                          description: Environment variables and port mappings
                         file_hash:
                           type: string
                           nullable: true
                           description: Content hash of the deployed code
+                        s3_key:
+                          type: string
+                          nullable: true
+                          description: S3 object key for the current code version
+                        search_params:
+                          type: string
+                          nullable: true
+                          description: Search query for instance selection
                         current_version_id:
                           type: integer
                           nullable: true
@@ -64,6 +76,10 @@ paths:
                         ttl:
                           type: number
                           nullable: true
+                        last_client_heartbeat:
+                          type: number
+                          nullable: true
+                          description: Unix timestamp of last client heartbeat
                         created_at:
                           type: number
                           description: Unix timestamp

--- a/api-reference/openapi/yaml/show_deployments.yaml
+++ b/api-reference/openapi/yaml/show_deployments.yaml
@@ -1,0 +1,117 @@
+openapi: 3.0.0
+info:
+  title: Show Deployments API
+  description: Retrieve a list of deployments for the authenticated user
+  version: 1.0.0
+servers:
+- url: https://console.vast.ai
+  description: Production server
+paths:
+  /api/v0/deployments/:
+    get:
+      summary: show deployments
+      description: |
+        Returns all deployments owned by the authenticated user.
+
+        CLI Usage: `vastai show deployments`
+      security:
+      - BearerAuth: []
+      responses:
+        '200':
+          description: A list of deployments
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  deployments:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                          example: 644
+                        name:
+                          type: string
+                          example: square
+                        tag:
+                          type: string
+                          example: default
+                        image:
+                          type: string
+                          example: vastai/base-image:latest
+                        endpoint_id:
+                          type: integer
+                          nullable: true
+                          example: 25121
+                        file_hash:
+                          type: string
+                          nullable: true
+                          description: Content hash of the deployed code
+                        current_version_id:
+                          type: integer
+                          nullable: true
+                        last_healthy_version_id:
+                          type: integer
+                          nullable: true
+                        storage:
+                          type: number
+                          example: 16.0
+                        ttl:
+                          type: number
+                          nullable: true
+                        created_at:
+                          type: number
+                          description: Unix timestamp
+                        updated_at:
+                          type: number
+                          description: Unix timestamp
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Too Many Requests
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: API requests too frequent endpoint threshold=3.0
+      tags:
+      - Serverless
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      description: API key must be provided in the Authorization header
+  schemas:
+    Error:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: false
+        error:
+          type: string
+        msg:
+          type: string
+x-rate-limit:
+  threshold: 3.0
+  per: request
+  description: Maximum request frequency per IP address for this endpoint
+x-cli-commands:
+- name: show deployments
+  description: Display user's current deployments
+  endpoint: /api/v0/deployments/
+  method: GET
+  example: vastai show deployments

--- a/api-reference/openapi/yaml/start_deployment.yaml
+++ b/api-reference/openapi/yaml/start_deployment.yaml
@@ -1,0 +1,91 @@
+openapi: 3.0.0
+info:
+  title: Start Deployment API
+  description: Start a stopped deployment
+  version: 1.0.0
+servers:
+- url: https://console.vast.ai
+  description: Production server
+paths:
+  /api/v0/deployment/{id}/start/:
+    post:
+      summary: start deployment
+      description: |
+        Starts (or restarts) the endpoint associated with a deployment. The autoscaler will begin recruiting workers according to the scaling policy.
+
+        CLI Usage: `vastai start deployment <id>`
+      security:
+      - BearerAuth: []
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Deployment ID
+        example: 644
+      responses:
+        '200':
+          description: Deployment started successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  endpoint_state:
+                    type: string
+                    example: active
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Deployment not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Too Many Requests
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: API requests too frequent endpoint threshold=2.0
+      tags:
+      - Serverless
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      description: API key must be provided in the Authorization header
+  schemas:
+    Error:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: false
+        error:
+          type: string
+        msg:
+          type: string
+x-rate-limit:
+  threshold: 2.0
+  per: request
+  description: Maximum request frequency per IP address for this endpoint
+x-cli-commands:
+- name: start deployment
+  description: Start a stopped deployment
+  endpoint: /api/v0/deployment/{id}/start/
+  method: POST
+  example: vastai start deployment 644

--- a/api-reference/openapi/yaml/stop_deployment.yaml
+++ b/api-reference/openapi/yaml/stop_deployment.yaml
@@ -1,0 +1,91 @@
+openapi: 3.0.0
+info:
+  title: Stop Deployment API
+  description: Stop a running deployment
+  version: 1.0.0
+servers:
+- url: https://console.vast.ai
+  description: Production server
+paths:
+  /api/v0/deployment/{id}/stop/:
+    post:
+      summary: stop deployment
+      description: |
+        Stops the endpoint associated with a deployment. The deployment is not deleted and can be restarted with the start deployment endpoint.
+
+        CLI Usage: `vastai stop deployment <id>`
+      security:
+      - BearerAuth: []
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: Deployment ID
+        example: 644
+      responses:
+        '200':
+          description: Deployment stopped successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  endpoint_state:
+                    type: string
+                    example: stopped
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Deployment not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Too Many Requests
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                    example: API requests too frequent endpoint threshold=2.0
+      tags:
+      - Serverless
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      description: API key must be provided in the Authorization header
+  schemas:
+    Error:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: false
+        error:
+          type: string
+        msg:
+          type: string
+x-rate-limit:
+  threshold: 2.0
+  per: request
+  description: Maximum request frequency per IP address for this endpoint
+x-cli-commands:
+- name: stop deployment
+  description: Stop a running deployment
+  endpoint: /api/v0/deployment/{id}/stop/
+  method: POST
+  example: vastai stop deployment 644

--- a/cli/reference/metrics-gpu-locations.mdx
+++ b/cli/reference/metrics-gpu-locations.mdx
@@ -1,0 +1,9 @@
+---
+title: "vastai metrics gpu-locations"
+sidebarTitle: "metrics gpu-locations"
+description: "Host command"
+---
+
+import MetricsGpuLocationsCLI from '/snippets/host/cli/metrics-gpu-locations.mdx';
+
+<MetricsGpuLocationsCLI />

--- a/cli/reference/metrics-gpu-trends.mdx
+++ b/cli/reference/metrics-gpu-trends.mdx
@@ -1,0 +1,9 @@
+---
+title: "vastai metrics gpu-trends"
+sidebarTitle: "metrics gpu-trends"
+description: "Host command"
+---
+
+import MetricsGpuTrendsCLI from '/snippets/host/cli/metrics-gpu-trends.mdx';
+
+<MetricsGpuTrendsCLI />

--- a/cli/reference/metrics-gpu.mdx
+++ b/cli/reference/metrics-gpu.mdx
@@ -1,0 +1,9 @@
+---
+title: "vastai metrics gpu"
+sidebarTitle: "metrics gpu"
+description: "Host command"
+---
+
+import MetricsGpuCLI from '/snippets/host/cli/metrics-gpu.mdx';
+
+<MetricsGpuCLI />

--- a/docs.json
+++ b/docs.json
@@ -358,7 +358,10 @@
                   "cli/reference/show-maints",
                   "cli/reference/unlist-machine",
                   "cli/reference/defrag-machines",
-                  "cli/reference/self-test-machine"
+                  "cli/reference/self-test-machine",
+                  "cli/reference/metrics-gpu",
+                  "cli/reference/metrics-gpu-trends",
+                  "cli/reference/metrics-gpu-locations"
                 ]
               }
             ]
@@ -597,6 +600,7 @@
             "pages": [
               "host/verification-stages",
               "host/how-to-self-test",
+              "host/market-metrics",
               "host/datacenter-status",
               "host/payment",
               "host/guide-to-taxes",
@@ -621,7 +625,10 @@
               "host/cli/show-maints",
               "host/cli/unlist-machine",
               "host/cli/defrag-machines",
-              "host/cli/self-test-machine"
+              "host/cli/self-test-machine",
+              "host/cli/metrics-gpu",
+              "host/cli/metrics-gpu-trends",
+              "host/cli/metrics-gpu-locations"
             ]
           },
           {

--- a/host/cli/metrics-gpu-locations.mdx
+++ b/host/cli/metrics-gpu-locations.mdx
@@ -1,0 +1,9 @@
+---
+title: "vastai metrics gpu-locations"
+sidebarTitle: "metrics gpu-locations"
+description: "Host command"
+---
+
+import MetricsGpuLocationsCLI from '/snippets/host/cli/metrics-gpu-locations.mdx';
+
+<MetricsGpuLocationsCLI />

--- a/host/cli/metrics-gpu-trends.mdx
+++ b/host/cli/metrics-gpu-trends.mdx
@@ -1,0 +1,9 @@
+---
+title: "vastai metrics gpu-trends"
+sidebarTitle: "metrics gpu-trends"
+description: "Host command"
+---
+
+import MetricsGpuTrendsCLI from '/snippets/host/cli/metrics-gpu-trends.mdx';
+
+<MetricsGpuTrendsCLI />

--- a/host/cli/metrics-gpu.mdx
+++ b/host/cli/metrics-gpu.mdx
@@ -1,0 +1,9 @@
+---
+title: "vastai metrics gpu"
+sidebarTitle: "metrics gpu"
+description: "Host command"
+---
+
+import MetricsGpuCLI from '/snippets/host/cli/metrics-gpu.mdx';
+
+<MetricsGpuCLI />

--- a/host/market-metrics.mdx
+++ b/host/market-metrics.mdx
@@ -51,7 +51,7 @@ Returns time-series data for supply, demand, and pricing. Defaults to RTX 5090, 
 ```bash
 vastai metrics gpu-trends                              # defaults
 vastai metrics gpu-trends "RTX 4090"                   # single GPU
-vastai metrics gpu-trends "RTX 4090,H100_SXM"          # multiple GPUs
+vastai metrics gpu-trends "RTX 4090, H100_SXM"          # multiple GPUs
 vastai metrics gpu-trends all                          # all GPU types
 vastai metrics gpu-trends "RTX 4090" --full            # all data points (vs sampled ~20)
 vastai metrics gpu-trends "RTX 4090" --raw             # JSON output
@@ -67,7 +67,7 @@ Returns geographic distribution of GPUs.
 ```bash
 vastai metrics gpu-locations                                     # unfiltered
 vastai metrics gpu-locations --verified true --datacenter true   # datacenter-verified only
-vastai metrics gpu-locations --gpu "RTX 4090,H100_SXM"           # specific GPU types
+vastai metrics gpu-locations --gpu "RTX 4090, H100_SXM"           # specific GPU types
 vastai metrics gpu-locations --rented false                      # only unrented
 vastai metrics gpu-locations --raw                               # JSON output
 ```
@@ -88,8 +88,8 @@ You can also query the data directly via the REST API. Pass your host API key as
 
 | Parameter | Applies to | Description |
 | --- | --- | --- |
-| `verified` | current, history, locations | `yes`, `no`, or `all` |
-| `hosting_type` | current, history, locations | `secure_cloud`, `community`, or `all` |
+| `verified` | current, history | `yes`, `no`, or `all` |
+| `hosting_type` | current, history | `secure_cloud`, `community`, or `all` |
 | `gpu_name` | history | GPU name (e.g. `RTX 4090`) |
 | `start` | history | Unix timestamp for range start |
 | `end` | history | Unix timestamp for range end |

--- a/host/market-metrics.mdx
+++ b/host/market-metrics.mdx
@@ -1,0 +1,120 @@
+---
+title: "GPU Market Metrics"
+sidebarTitle: "Market Metrics"
+description: "Track GPU supply, demand, pricing, and locations across the Vast marketplace"
+---
+
+Vast provides real-time and historical data on GPU supply, demand, pricing, and geographic distribution across the marketplace. You can use this data to make informed decisions about pricing your machines and understanding demand for specific GPU types.
+
+## Accessing the data
+
+There are three ways to access market metrics:
+
+1. **Dashboards** at [cloud.vast.ai/host/market/](https://cloud.vast.ai/host/market/)
+2. **CLI** via `vastai metrics` subcommands (requires `pip install vastai`, v1.0.4+)
+3. **REST API** endpoints (see [API reference](#api-endpoints) below)
+
+All three require a **host API key**. Regular client keys will receive a `401` error.
+
+## Dashboards
+
+Three views are available at [cloud.vast.ai/host/market/](https://cloud.vast.ai/host/market/):
+
+- **Availability & Pricing** — Historical supply/demand counts and P10/median/P90 pricing over time
+- **GPU Overview** — Current supply/demand counts, pricing, and stats for each GPU type
+- **GPU Locations** — Geographic distribution of GPUs across the platform
+
+## CLI commands
+
+Install or upgrade the CLI:
+
+```bash
+pip install --upgrade vastai
+```
+
+### Current snapshot — `vastai metrics gpu`
+
+Returns current supply, demand, and pricing for all GPU types.
+
+```bash
+vastai metrics gpu                                # all GPU types
+vastai metrics gpu --verified true --datacenter true
+vastai metrics gpu --raw                          # JSON output
+```
+
+See [full reference](/host/cli/metrics-gpu).
+
+### Historical trends — `vastai metrics gpu-trends`
+
+Returns time-series data for supply, demand, and pricing. Defaults to RTX 5090, 4090, and 3090 over the last 24 hours.
+
+```bash
+vastai metrics gpu-trends                              # defaults
+vastai metrics gpu-trends "RTX 4090"                   # single GPU
+vastai metrics gpu-trends "RTX 4090,H100_SXM"          # multiple GPUs
+vastai metrics gpu-trends all                          # all GPU types
+vastai metrics gpu-trends "RTX 4090" --full            # all data points (vs sampled ~20)
+vastai metrics gpu-trends "RTX 4090" --raw             # JSON output
+vastai metrics gpu-trends "RTX 4090" --start 1773298800 --end 1773817200 --step 3600
+```
+
+See [full reference](/host/cli/metrics-gpu-trends).
+
+### Location data — `vastai metrics gpu-locations`
+
+Returns geographic distribution of GPUs.
+
+```bash
+vastai metrics gpu-locations                                     # unfiltered
+vastai metrics gpu-locations --verified true --datacenter true   # datacenter-verified only
+vastai metrics gpu-locations --gpu "RTX 4090,H100_SXM"           # specific GPU types
+vastai metrics gpu-locations --rented false                      # only unrented
+vastai metrics gpu-locations --raw                               # JSON output
+```
+
+See [full reference](/host/cli/metrics-gpu-locations).
+
+## API endpoints
+
+You can also query the data directly via the REST API. Pass your host API key as a Bearer token.
+
+| Endpoint | Description |
+| --- | --- |
+| `GET /api/v0/metrics/gpu/current/` | Current snapshot of all GPU types |
+| `GET /api/v0/metrics/gpu/history/` | Time-series supply/demand and pricing |
+| `GET /api/v0/metrics/gpu/locations/` | Geographic distribution |
+
+### Query parameters
+
+| Parameter | Applies to | Description |
+| --- | --- | --- |
+| `verified` | current, history, locations | `yes`, `no`, or `all` |
+| `hosting_type` | current, history, locations | `secure_cloud`, `community`, or `all` |
+| `gpu_name` | history | GPU name (e.g. `RTX 4090`) |
+| `start` | history | Unix timestamp for range start |
+| `end` | history | Unix timestamp for range end |
+| `step` | history | Seconds between data points (e.g. `3600` for hourly) |
+
+### Examples
+
+```bash
+# Current snapshot — verified datacenter GPUs
+curl -H "Authorization: Bearer $API_KEY" \
+  "https://console.vast.ai/api/v0/metrics/gpu/current/?verified=yes&hosting_type=secure_cloud"
+
+# Historical trends — RTX 4090, hourly steps
+curl -H "Authorization: Bearer $API_KEY" \
+  "https://console.vast.ai/api/v0/metrics/gpu/history/?gpu_name=RTX+4090&verified=yes&start=1773298800&end=1773817200&step=3600"
+
+# Locations
+curl -H "Authorization: Bearer $API_KEY" \
+  "https://console.vast.ai/api/v0/metrics/gpu/locations/"
+```
+
+## Data freshness
+
+Market metrics data is updated every 5 minutes. Location data is cached for up to 2 hours since it changes less frequently.
+
+### Rate limits
+
+Each endpoint allows up to **5 requests per second** per user. For large historical queries, the backend automatically adjusts the resolution to keep response sizes reasonable.

--- a/snippets/host/cli/metrics-gpu-locations.mdx
+++ b/snippets/host/cli/metrics-gpu-locations.mdx
@@ -1,0 +1,62 @@
+Show geographic distribution of GPUs on the marketplace
+
+<Note>This is a **host** command. Requires a host API key (v1.0.4+).</Note>
+
+## Usage
+
+```bash
+vastai metrics gpu-locations [OPTIONS]
+```
+
+## Options
+
+<ParamField path="--verified" type="string">
+  Filter by verification status (`true` or `false`)
+</ParamField>
+
+<ParamField path="--datacenter" type="string">
+  Filter by datacenter status (`true` or `false`)
+</ParamField>
+
+<ParamField path="--gpu" type="string">
+  Comma-separated GPU names to filter by (e.g. `"RTX 4090,H100_SXM"`)
+</ParamField>
+
+<ParamField path="--rented" type="string">
+  Filter by rental status (`true` or `false`)
+</ParamField>
+
+## Description
+
+Returns the geographic distribution of GPUs across the Vast marketplace. Filtering is applied locally after fetching the dataset, so filter combinations do not affect server performance.
+
+## Examples
+
+```bash
+# All locations, unfiltered
+vastai metrics gpu-locations
+
+# Datacenter-verified only
+vastai metrics gpu-locations --verified true --datacenter true
+
+# Specific GPU types
+vastai metrics gpu-locations --gpu "RTX 4090,H100_SXM"
+
+# Only unrented GPUs
+vastai metrics gpu-locations --rented false
+
+# JSON output
+vastai metrics gpu-locations --raw
+```
+
+## Global Options
+
+The following options are available for all commands:
+
+| Option | Description |
+| --- | --- |
+| `--url URL` | Server REST API URL |
+| `--retry N` | Retry limit |
+| `--raw` | Output machine-readable JSON |
+| `--explain` | Verbose explanation of API calls |
+| `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |

--- a/snippets/host/cli/metrics-gpu-locations.mdx
+++ b/snippets/host/cli/metrics-gpu-locations.mdx
@@ -11,11 +11,11 @@ vastai metrics gpu-locations [OPTIONS]
 ## Options
 
 <ParamField path="--verified" type="string">
-  Filter by verification status (`true` or `false`)
+  Filter by verification status (`true`, `false`, or `all`). Defaults to `all`.
 </ParamField>
 
 <ParamField path="--datacenter" type="string">
-  Filter by datacenter status (`true` or `false`)
+  Filter by datacenter hosting type (`true`, `false`, or `all`). Defaults to `all`.
 </ParamField>
 
 <ParamField path="--gpu" type="string">
@@ -23,7 +23,7 @@ vastai metrics gpu-locations [OPTIONS]
 </ParamField>
 
 <ParamField path="--rented" type="string">
-  Filter by rental status (`true` or `false`)
+  Filter by rental status (`true`, `false`, or `all`). Defaults to `all`.
 </ParamField>
 
 ## Description

--- a/snippets/host/cli/metrics-gpu-locations.mdx
+++ b/snippets/host/cli/metrics-gpu-locations.mdx
@@ -1,6 +1,6 @@
 Show geographic distribution of GPUs on the marketplace
 
-<Note>This is a **host** command. Requires a host API key (v1.0.4+).</Note>
+<Note>This is a **host** command, used for managing machines you are renting out on Vast.ai.</Note>
 
 ## Usage
 
@@ -19,7 +19,7 @@ vastai metrics gpu-locations [OPTIONS]
 </ParamField>
 
 <ParamField path="--gpu" type="string">
-  Comma-separated GPU names to filter by (e.g. `"RTX 4090,H100_SXM"`)
+  Comma-separated GPU names to filter by (e.g. `"RTX 4090, H100_SXM"`)
 </ParamField>
 
 <ParamField path="--rented" type="string">
@@ -40,7 +40,7 @@ vastai metrics gpu-locations
 vastai metrics gpu-locations --verified true --datacenter true
 
 # Specific GPU types
-vastai metrics gpu-locations --gpu "RTX 4090,H100_SXM"
+vastai metrics gpu-locations --gpu "RTX 4090, H100_SXM"
 
 # Only unrented GPUs
 vastai metrics gpu-locations --rented false

--- a/snippets/host/cli/metrics-gpu-trends.mdx
+++ b/snippets/host/cli/metrics-gpu-trends.mdx
@@ -16,6 +16,14 @@ vastai metrics gpu-trends [GPU_NAMES] [OPTIONS]
 
 ## Options
 
+<ParamField path="--verified" type="string">
+  Filter by verification status (`true`, `false`, or `all`). Defaults to `all`.
+</ParamField>
+
+<ParamField path="--datacenter" type="string">
+  Filter by datacenter hosting type (`true`, `false`, or `all`). Defaults to `all`.
+</ParamField>
+
 <ParamField path="--full" type="boolean">
   Return all data points instead of a sampled subset (~20 points)
 </ParamField>
@@ -56,6 +64,9 @@ vastai metrics gpu-trends "RTX 4090" --full
 
 # JSON output
 vastai metrics gpu-trends "RTX 4090" --raw
+
+# Verified datacenter GPUs only
+vastai metrics gpu-trends all --verified true --datacenter true
 
 # Custom time range with hourly resolution
 vastai metrics gpu-trends "RTX 4090" --start 1773298800 --end 1773817200 --step 3600

--- a/snippets/host/cli/metrics-gpu-trends.mdx
+++ b/snippets/host/cli/metrics-gpu-trends.mdx
@@ -1,6 +1,6 @@
 Show historical GPU market trends (supply, demand, pricing over time)
 
-<Note>This is a **host** command. Requires a host API key (v1.0.4+).</Note>
+<Note>This is a **host** command, used for managing machines you are renting out on Vast.ai.</Note>
 
 ## Usage
 
@@ -11,7 +11,7 @@ vastai metrics gpu-trends [GPU_NAMES] [OPTIONS]
 ## Arguments
 
 <ParamField path="GPU_NAMES" type="string">
-  Comma-separated GPU names to query (e.g. `"RTX 4090"`, `"RTX 4090,H100_SXM"`). Use `all` for all GPU types. Defaults to RTX 5090, 4090, and 3090. Underscores are accepted in place of spaces.
+  Comma-separated GPU names to query (e.g. `"RTX 4090"`, `"RTX 4090, H100_SXM"`). Use `all` for all GPU types. Defaults to RTX 5090, 4090, and 3090. Underscores are accepted in place of spaces.
 </ParamField>
 
 ## Options
@@ -46,7 +46,7 @@ vastai metrics gpu-trends
 vastai metrics gpu-trends "RTX 4090"
 
 # Multiple GPUs
-vastai metrics gpu-trends "RTX 4090,H100_SXM"
+vastai metrics gpu-trends "RTX 4090, H100_SXM"
 
 # All GPU types
 vastai metrics gpu-trends all

--- a/snippets/host/cli/metrics-gpu-trends.mdx
+++ b/snippets/host/cli/metrics-gpu-trends.mdx
@@ -1,0 +1,74 @@
+Show historical GPU market trends (supply, demand, pricing over time)
+
+<Note>This is a **host** command. Requires a host API key (v1.0.4+).</Note>
+
+## Usage
+
+```bash
+vastai metrics gpu-trends [GPU_NAMES] [OPTIONS]
+```
+
+## Arguments
+
+<ParamField path="GPU_NAMES" type="string">
+  Comma-separated GPU names to query (e.g. `"RTX 4090"`, `"RTX 4090,H100_SXM"`). Use `all` for all GPU types. Defaults to RTX 5090, 4090, and 3090. Underscores are accepted in place of spaces.
+</ParamField>
+
+## Options
+
+<ParamField path="--full" type="boolean">
+  Return all data points instead of a sampled subset (~20 points)
+</ParamField>
+
+<ParamField path="--start" type="integer">
+  Unix timestamp for range start
+</ParamField>
+
+<ParamField path="--end" type="integer">
+  Unix timestamp for range end
+</ParamField>
+
+<ParamField path="--step" type="integer">
+  Seconds between data points (e.g. `3600` for hourly)
+</ParamField>
+
+## Description
+
+Returns time-series data for GPU supply, demand, and pricing. By default, queries the last 24 hours for RTX 5090, 4090, and 3090 and returns a sampled set of roughly 20 data points. Use `--full` to get all available data points, or `--start`/`--end`/`--step` for custom time ranges.
+
+## Examples
+
+```bash
+# Defaults (RTX 5090, 4090, 3090 over last 24h)
+vastai metrics gpu-trends
+
+# Single GPU
+vastai metrics gpu-trends "RTX 4090"
+
+# Multiple GPUs
+vastai metrics gpu-trends "RTX 4090,H100_SXM"
+
+# All GPU types
+vastai metrics gpu-trends all
+
+# All data points (not sampled)
+vastai metrics gpu-trends "RTX 4090" --full
+
+# JSON output
+vastai metrics gpu-trends "RTX 4090" --raw
+
+# Custom time range with hourly resolution
+vastai metrics gpu-trends "RTX 4090" --start 1773298800 --end 1773817200 --step 3600
+```
+
+## Global Options
+
+The following options are available for all commands:
+
+| Option | Description |
+| --- | --- |
+| `--url URL` | Server REST API URL |
+| `--retry N` | Retry limit |
+| `--raw` | Output machine-readable JSON |
+| `--explain` | Verbose explanation of API calls |
+| `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |

--- a/snippets/host/cli/metrics-gpu.mdx
+++ b/snippets/host/cli/metrics-gpu.mdx
@@ -1,0 +1,48 @@
+Show current GPU market metrics (supply, demand, pricing)
+
+<Note>This is a **host** command. Requires a host API key (v1.0.4+).</Note>
+
+## Usage
+
+```bash
+vastai metrics gpu [OPTIONS]
+```
+
+## Options
+
+<ParamField path="--verified" type="string">
+  Filter by verification status (`true` or `false`)
+</ParamField>
+
+<ParamField path="--datacenter" type="string">
+  Filter by datacenter status (`true` or `false`)
+</ParamField>
+
+## Description
+
+Returns a current snapshot of supply, demand, and pricing across all GPU types on the Vast marketplace. Use filters to narrow results to verified or datacenter machines.
+
+## Examples
+
+```bash
+# All GPU types
+vastai metrics gpu
+
+# Verified datacenter GPUs only
+vastai metrics gpu --verified true --datacenter true
+
+# JSON output
+vastai metrics gpu --raw
+```
+
+## Global Options
+
+The following options are available for all commands:
+
+| Option | Description |
+| --- | --- |
+| `--url URL` | Server REST API URL |
+| `--retry N` | Retry limit |
+| `--raw` | Output machine-readable JSON |
+| `--explain` | Verbose explanation of API calls |
+| `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |

--- a/snippets/host/cli/metrics-gpu.mdx
+++ b/snippets/host/cli/metrics-gpu.mdx
@@ -11,11 +11,11 @@ vastai metrics gpu [OPTIONS]
 ## Options
 
 <ParamField path="--verified" type="string">
-  Filter by verification status (`true` or `false`)
+  Filter by verification status (`true`, `false`, or `all`). Defaults to `all`.
 </ParamField>
 
 <ParamField path="--datacenter" type="string">
-  Filter by datacenter status (`true` or `false`)
+  Filter by datacenter hosting type (`true`, `false`, or `all`). Defaults to `all`.
 </ParamField>
 
 ## Description

--- a/snippets/host/cli/metrics-gpu.mdx
+++ b/snippets/host/cli/metrics-gpu.mdx
@@ -1,6 +1,6 @@
 Show current GPU market metrics (supply, demand, pricing)
 
-<Note>This is a **host** command. Requires a host API key (v1.0.4+).</Note>
+<Note>This is a **host** command, used for managing machines you are renting out on Vast.ai.</Note>
 
 ## Usage
 


### PR DESCRIPTION
## Summary

  - Add a new Market Metrics guide under the Host tab explaining dashboards, CLI commands, and API access for GPU supply/demand/pricing/location data
  - Add CLI reference pages for `metrics gpu`, `metrics gpu-trends`, and `metrics gpu-locations` (Host tab + CLI & SDK tab, shared via snippets)
  - Add OpenAPI specs for 3 metrics endpoints (`/metrics/gpu/current/`, `/metrics/gpu/history/`, `/metrics/gpu/locations/`) and 4 deployment endpoints (`show deployment`, `show deployments`, `start deployment`, `stop deployment`)

  ## New pages

  - `host/market-metrics` (guide with dashboard links, CLI examples, API reference, rate limits)
  - `host/cli/metrics-gpu`, `metrics-gpu-trends`, `metrics-gpu-locations`
  - `cli/reference/metrics-gpu`, `metrics-gpu-trends`, `metrics-gpu-locations`

  ## New OpenAPI specs

  - `metrics_gpu.yaml`, `metrics_gpu_trends.yaml`, `metrics_gpu_locations.yaml`
  - `show_deployment.yaml`, `show_deployments.yaml`, `start_deployment.yaml`, `stop_deployment.yaml`
