### PR TITLE
Add CODEOWNERS to auto-request David on serverless docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Serverless docs — auto-request David as reviewer (AUTO-1459)
+/guides/serverless/                  @DavidatVast
+/sdk/python/serverless/              @DavidatVast
+/images/serverless*                  @DavidatVast
+/images/getting-started-serverless*  @DavidatVast


### PR DESCRIPTION
add david as default reviewer for serverless docs