### PR TITLE
docs(agents): use owner/repo shorthand for skills install command

### DIFF
--- a/guides/get-started/agents.mdx
+++ b/guides/get-started/agents.mdx
@@ -14,7 +14,7 @@ The `vastai` agent skill lets AI coding assistants drive Vast.ai on your behalf 
 Install the skill into your coding agent with one command:
 
 ```bash
-npx skills add https://github.com/vast-ai/vast-cli --skill vastai
+npx skills add vast-ai/vast-cli --skill vastai
 ```
 
 Restart your coding tool after installing so it picks up the new skill.


### PR DESCRIPTION
## Summary
The skills install command on `/guides/get-started/agents` used a verbose GitHub URL:

```
npx skills add https://github.com/vast-ai/vast-cli --skill vastai
```

The canonical [vast-cli README](https://github.com/vast-ai/vast-cli#ai-agents) uses the `owner/repo` shorthand, which resolves to the same repo:

```
npx skills add vast-ai/vast-cli --skill vastai
```

This switches the docs to the shorthand for consistency. `--skill vastai` is kept intentionally — the repo ships two skills (`vastai/` renter + `vastai_sdk/`), and the flag installs only the renter skill.

## Test plan
- [ ] `npx skills add vast-ai/vast-cli --skill vastai` resolves and installs the renter skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)