### PR TITLE
docs(agents): use marketplace install flow for agent plugins

### DIFF
--- a/guides/get-started/agents.mdx
+++ b/guides/get-started/agents.mdx
@@ -60,42 +60,35 @@ Invoke them as **`/vastai:<command>`** in Claude Code and **`/prompts:vast-<comm
 
 <Tabs>
   <Tab title="Claude Code">
-    Install from source:
+    Inside Claude Code, add the marketplace and install the plugin:
 
-    ```bash
-    git clone https://github.com/vast-ai/vast-claude-plugin.git
-    claude --plugin-dir ./vast-claude-plugin
+    ```text
+    /plugin marketplace add vast-ai/vast-claude-plugin
+    /plugin install vastai
     ```
-
-    <Note>
-      Marketplace install (`/plugin install vastai@…`) is coming once the plugin
-      is published to a Claude Code marketplace. For now, load it from source with
-      `--plugin-dir`.
-    </Note>
 
     Then run `/vastai:setup` once to store your API key, register your SSH public key, and verify the credential. Source: [`vast-ai/vast-claude-plugin`](https://github.com/vast-ai/vast-claude-plugin).
   </Tab>
   <Tab title="Codex">
-    Install from source:
+    In your terminal, add the marketplace and open the plugin browser:
 
     ```bash
-    git clone https://github.com/vast-ai/vast-codex-plugin.git
-    cd vast-codex-plugin
-    ./install.sh
+    codex plugin marketplace add vast-ai/vast-codex-plugin
+    codex plugin        # plugin browser → pick "Vast.ai" → Install
     ```
 
-    This installs the skills into `~/.agents/skills/` and the prompts into `~/.codex/prompts/`. Restart your Codex session, then run `/prompts:vast-setup` once. Source: [`vast-ai/vast-codex-plugin`](https://github.com/vast-ai/vast-codex-plugin).
+    Restart your Codex session, then run `/prompts:vast-setup` once. Source: [`vast-ai/vast-codex-plugin`](https://github.com/vast-ai/vast-codex-plugin).
   </Tab>
   <Tab title="Cursor">
     No slash commands — Cursor is natural-language driven. The plugin adds both skills plus an auto-attach rule that points Cursor at the renter skill when you edit infrastructure files (`*.tf`, `*.yaml`, `infra/`, `deploy/`).
 
-    In Cursor 2.5+, run the install command in the editor:
+    Install it from the Cursor Dashboard → **Settings → Plugins → Team Marketplaces → Import**, then paste:
 
     ```text
-    /add-plugin vastai
+    https://github.com/vast-ai/vast-cursor-plugin
     ```
 
-    Or clone and run `install.sh` to install ahead of marketplace acceptance. Then say *"Configure my Vast.ai CLI."* in Agent chat to walk through setup. Source: [`vast-ai/vast-cursor-plugin`](https://github.com/vast-ai/vast-cursor-plugin).
+    Then say *"Configure my Vast.ai CLI."* in Agent chat to walk through setup. Source: [`vast-ai/vast-cursor-plugin`](https://github.com/vast-ai/vast-cursor-plugin).
   </Tab>
 </Tabs>
 


### PR DESCRIPTION
## Summary
Updates the install instructions on **Using Vast.ai with Agents** (`guides/get-started/agents.mdx`) to use the new marketplace flow instead of source installs, for all three agent plugins:

- **Claude Code** — `/plugin marketplace add vast-ai/vast-claude-plugin` → `/plugin install vastai`. Removed the obsolete "marketplace coming soon" note.
- **Codex** — `codex plugin marketplace add vast-ai/vast-codex-plugin` → `codex plugin` browser → pick "Vast.ai" → Install.
- **Cursor** — Dashboard → Settings → Plugins → Team Marketplaces → Import → paste the repo URL.

Post-install `setup` guidance and source links are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)