### PR TITLE
Remove disable_bundling from search_offers SDK reference

### DIFF
--- a/sdk/python/reference/search-offers.mdx
+++ b/sdk/python/reference/search-offers.mdx
@@ -13,7 +13,6 @@ VastAI.search_offers(
     no_default: bool = False,
     new: bool = False,
     limit: Optional[int] = None,
-    disable_bundling: bool = False,
     storage: Optional[float] = None,
     order: Optional[str] = None,
     query: Optional[str] = None
@@ -36,10 +35,6 @@ VastAI.search_offers(
 
 <ParamField path="limit" type="Optional[int]">
   Maximum number of results to return.
-</ParamField>
-
-<ParamField path="disable_bundling" type="bool" default="False">
-  Disable offer bundling (show individual machine slots).
 </ParamField>
 
 <ParamField path="storage" type="Optional[float]">


### PR DESCRIPTION
## What
Removes the `disable_bundling` parameter from the `search_offers` Python SDK reference page.

## Why
`disable_bundling` is a deprecated bundling flag (see the vast-cli offers helpers, where it's documented as "Deprecated bundling flag"). It should not be surfaced in the published API/SDK docs.

## Changes
`sdk/python/reference/search-offers.mdx`:
- Remove `disable_bundling: bool = False,` from the signature block
- Remove the `<ParamField path="disable_bundling">` block

Companion code cleanup in vast-cli: vast-ai/vast-cli#469

🤖 Generated with [Claude Code](https://claude.com/claude-code)