### PR TITLE
Update logs.mdx

### DIFF
--- a/sdk/python/reference/logs.mdx
+++ b/sdk/python/reference/logs.mdx
@@ -8,13 +8,13 @@ Retrieve logs for an instance.
 ## Signature
 
 ```python
-VastAI.logs(INSTANCE_ID: int, tail: Optional[str] = None) -> str
+VastAI.logs(instance_id: int, tail: Optional[str] = None) -> str
 ```
 
 ## Parameters
 
-<ParamField path="INSTANCE_ID" type="int" required>
-  INSTANCE_ID
+<ParamField path="instance_id" type="int" required>
+  instance_id
 </ParamField>
 
 <ParamField path="tail" type="Optional[str]">
@@ -31,6 +31,6 @@ VastAI.logs(INSTANCE_ID: int, tail: Optional[str] = None) -> str
 from vastai import VastAI
 
 client = VastAI(api_key="YOUR_API_KEY")
-result = client.logs(INSTANCE_ID=12345)
+result = client.logs(instance_id=12345)
 print(result)
 ```


### PR DESCRIPTION
Fixes a TypeError in the VastAI.logs() function documentation. The docs previously listed the parameter as uppercase INSTANCE_ID, but the underlying Python method expects lowercase instance_id. Correcting this prevents runtime errors for users copying code from the documentation.