### PR TITLE
docs(cli): drop deprecated wget vast.py install instructions

### DIFF
--- a/cli/hello-world.mdx
+++ b/cli/hello-world.mdx
@@ -10,20 +10,20 @@ This guide walks through the core workflow: install the CLI, authenticate, searc
 ## Prerequisites
 
 - A Vast.ai account with credit (~$0.01-0.05, depending on test instance run time)
-- Python 3 installed
+- Python 3 installed (only needed if installing via pip)
 
 ## 1. Install the CLI
 
-Install from PyPI:
+On Linux, macOS, or WSL, install with a single command, no Python setup required:
+
+```bash
+curl -fsSL https://vast.ai/install.sh | bash
+```
+
+On Windows, or if you'd rather install via Python, use pip instead:
 
 ```bash
 pip install vastai
-```
-
-Or grab the latest version directly from GitHub:
-
-```bash
-wget https://raw.githubusercontent.com/vast-ai/vast-cli/master/vast.py -O vastai && chmod +x vastai
 ```
 
 Verify the installation:

--- a/guides/get-started/agents.mdx
+++ b/guides/get-started/agents.mdx
@@ -19,7 +19,7 @@ npx skills add vast-ai/vast-cli --skill vastai
 
 Restart your coding tool after installing so it picks up the new skill.
 
-The skill calls the `vastai` CLI under the hood. If it isn't already installed, run `pip install vastai` (or your agent will install it on first use) — see the [CLI getting-started guide](/cli/hello-world) for alternatives.
+The skill calls the `vastai` CLI under the hood. If it isn't already installed, run `curl -fsSL https://vast.ai/install.sh | bash` (or your agent will install it on first use) — see the [CLI getting-started guide](/cli/hello-world) for alternatives, including `pip install vastai` on Windows.
 
 ### Authenticate
 

--- a/snippets/host/cli/list-machines.mdx
+++ b/snippets/host/cli/list-machines.mdx
@@ -64,7 +64,7 @@ vastai list machines IDs [options]
 
 This variant can be used to list or update the listings for multiple machines at once with the same args.
 You could extend the end dates of all your machines using a command combo like this:
-./vast.py list machines $(./vast.py show machines -q) -e 12/31/2024 `--retry` 6
+vastai list machines $(vastai show machines -q) -e 12/31/2024 `--retry` 6
 
 ## Examples
 


### PR DESCRIPTION
## Summary
- Replace the deprecated `wget .../vast.py` GitHub install step in the CLI Hello World guide with the current `install.sh` (Linux/macOS/WSL) and `pip install vastai` (Windows/Python) paths, matching the vast-cli README but simplified for a public getting-started audience.
- Fix a stray `./vast.py` example in the `list machines` host-command snippet to use `vastai`.

## Test plan
- [x] Reviewed rendered instructions match vast-cli README's install guidance
- [x] Grepped docs repo for other `wget`/`vast.py`/`raw.githubusercontent.com/vast-ai/vast-cli` install references — none remaining