### PR TITLE
docs: volumes now support Cloud Copy — correct stale volume copy restrictions

### DIFF
--- a/cli/reference/copy.mdx
+++ b/cli/reference/copy.mdx
@@ -43,7 +43,7 @@ Supported location formats:
 
 You should not copy to /root or / as a destination directory, as this can mess up the permissions on your instance ssh folder, breaking future copy operations (as they use ssh authentication)
 You can see more information about constraints here: https://vast.ai/docs/gpu-instances/data-movement#constraints
-Volume copy is currently only supported for copying to other volumes or instances, not cloud services or local.
+Volume copy supports copying to other volumes, instances, and cloud services (via your Cloud Connections). Copying between a volume and a local path is not supported.
 
 ## Examples
 

--- a/guides/instances/storage/volumes.mdx
+++ b/guides/instances/storage/volumes.mdx
@@ -155,7 +155,14 @@ vastai copy V.<volume_id>:/data/ C.<instance_id>:/workspace/
 vastai copy C.<instance_id>:/workspace/ V.<volume_id>:/data/
 ```
 
-Note: Volume copy does not support cloud storage endpoints (S3, Google Drive, etc.) or local paths, only volume-to-volume and volume-to-instance transfers are supported.
+Volumes also work with [Cloud Copy](/guides/instances/storage/cloud-sync), so you can copy between a volume and a connected cloud storage provider (S3, Google Drive, etc.):
+
+```text Text
+vastai copy s3.<connection_id>:/data/ V.<volume_id>:/data/
+vastai copy V.<volume_id>:/data/ s3.<connection_id>:/data/
+```
+
+Note: Copying directly between a volume and your local machine is not supported.
 
 ### How can I delete my volume?
 


### PR DESCRIPTION
## What

Volumes now work with the Cloud Copy feature, but two docs pages still said the opposite. This PR corrects both:

- **`guides/instances/storage/volumes.mdx`** — the FAQ note claimed volume copy does not support cloud storage endpoints (S3, Google Drive, etc.). Replaced with a positive statement plus `vastai copy` examples for volume↔cloud in both directions, linking to the Cloud Sync guide.
- **`cli/reference/copy.mdx`** — the restriction line now says volume copy supports volumes, instances, and cloud services.

## Verified against backend

`copy_direct` dispatches `Volume To Cloud` / `Cloud To Volume` to `execute_volume_cloud_copy`, and the CLI's `vastai copy` passes `V.`/cloud-service ids straight to that endpoint. Volume↔**local** remains unsupported, so both pages keep that one restriction.

## Heads-up

`cli/reference/copy.mdx` is auto-generated from the `copy` command epilog in `vast-cli/vast.py` (line ~1595), which still carries the stale sentence — the next regen will revert this page unless the CLI source is updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)