### PR TITLE
docs(cli): use curl installer in remaining CLI install snippets

### DIFF
--- a/cli/hello-world.mdx
+++ b/cli/hello-world.mdx
@@ -26,11 +26,22 @@ On Windows, or if you'd rather install via Python, use pip instead:
 pip install vastai
 ```
 
-Verify the installation:
+Open a new terminal (so your shell picks up the updated PATH), then verify the installation:
 
 ```bash
 vastai --help
 ```
+
+<Note>
+  If you get `command not found` without opening a new terminal, run `export
+  PATH="$HOME/.local/bin:$PATH"` in your current shell. Neither install
+  method updates the PATH of an already-running shell: the curl installer
+  only adds `~/.local/bin` to your shell's startup file (`.bashrc`/`.zshrc`)
+  for future terminals, and `pip install vastai` doesn't touch your PATH or
+  shell config at all — if pip fell back to `pip install --user`, the
+  `vastai` script also lands in `~/.local/bin`, and whether that's already on
+  your PATH depends on your system.
+</Note>
 
 ## 2. Set Your API Key
 

--- a/cli/hello-world.mdx
+++ b/cli/hello-world.mdx
@@ -14,13 +14,13 @@ This guide walks through the core workflow: install the CLI, authenticate, searc
 
 ## 1. Install the CLI
 
-On Linux, macOS, or WSL, install with a single command, no Python setup required:
+Install the CLI on Linux, macOS, or WSL:
 
 ```bash
 curl -fsSL https://vast.ai/install.sh | bash
 ```
 
-On Windows, or if you'd rather install via Python, use pip instead:
+On Windows, or to use the Python SDK, install from PyPI:
 
 ```bash
 pip install vastai

--- a/cli/hello-world.mdx
+++ b/cli/hello-world.mdx
@@ -33,14 +33,11 @@ vastai --help
 ```
 
 <Note>
-  If you get `command not found` without opening a new terminal, run `export
-  PATH="$HOME/.local/bin:$PATH"` in your current shell. Neither install
-  method updates the PATH of an already-running shell: the curl installer
-  only adds `~/.local/bin` to your shell's startup file (`.bashrc`/`.zshrc`)
-  for future terminals, and `pip install vastai` doesn't touch your PATH or
-  shell config at all — if pip fell back to `pip install --user`, the
-  `vastai` script also lands in `~/.local/bin`, and whether that's already on
-  your PATH depends on your system.
+  If you still get `command not found` in a new terminal, neither install
+  method updates the PATH of a shell that was already running: the curl
+  installer only adds `~/.local/bin` to your shell's startup file
+  (`.bashrc`/`.zshrc`) for future terminals, and `pip install vastai` doesn't
+  touch your PATH or shell config at all.
 </Note>
 
 ## 2. Set Your API Key

--- a/cli/hello-world.mdx
+++ b/cli/hello-world.mdx
@@ -32,14 +32,6 @@ Open a new terminal (so your shell picks up the updated PATH), then verify the i
 vastai --help
 ```
 
-<Note>
-  If you still get `command not found` in a new terminal, neither install
-  method updates the PATH of a shell that was already running: the curl
-  installer only adds `~/.local/bin` to your shell's startup file
-  (`.bashrc`/`.zshrc`) for future terminals, and `pip install vastai` doesn't
-  touch your PATH or shell config at all.
-</Note>
-
 ## 2. Set Your API Key
 
 Generate an API key from the [Keys page](https://cloud.vast.ai/manage-keys/) by clicking **+New**. Copy the key, you'll only see it once.

--- a/examples/ai-agents/autoresearch.mdx
+++ b/examples/ai-agents/autoresearch.mdx
@@ -21,7 +21,8 @@ This guide walks you through setting up autoresearch on a Vast.ai GPU instance w
 Install the Vast CLI if you haven't already:
 
 ```bash
-pip install vastai
+curl -fsSL https://vast.ai/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
 vastai set api-key YOUR_API_KEY
 ```
 

--- a/examples/ai-agents/autoresearch.mdx
+++ b/examples/ai-agents/autoresearch.mdx
@@ -22,7 +22,6 @@ Install the Vast CLI if you haven't already:
 
 ```bash
 curl -fsSL https://vast.ai/install.sh | bash
-export PATH="$HOME/.local/bin:$PATH"
 vastai set api-key YOUR_API_KEY
 ```
 

--- a/examples/ai-agents/browsesafe.mdx
+++ b/examples/ai-agents/browsesafe.mdx
@@ -87,7 +87,8 @@ BrowseSafe-Bench covers 11 attack types:
 ### Step 1: Install Vast.ai CLI
 
 ```bash Bash
-pip install --upgrade vastai
+curl -fsSL https://vast.ai/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
 vastai set api-key <your-api-key>
 ```
 

--- a/examples/ai-agents/browsesafe.mdx
+++ b/examples/ai-agents/browsesafe.mdx
@@ -88,7 +88,6 @@ BrowseSafe-Bench covers 11 attack types:
 
 ```bash Bash
 curl -fsSL https://vast.ai/install.sh | bash
-export PATH="$HOME/.local/bin:$PATH"
 vastai set api-key <your-api-key>
 ```
 

--- a/examples/ai-agents/openclaw.mdx
+++ b/examples/ai-agents/openclaw.mdx
@@ -34,7 +34,8 @@ This gives you a private AI assistant powered by your own GPU instance, no API k
 ## Step 1: Install the Vast.ai CLI
 
 ```bash Bash
-pip install --upgrade vastai
+curl -fsSL https://vast.ai/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
 vastai set api-key YOUR_API_KEY
 ```
 

--- a/examples/ai-agents/openclaw.mdx
+++ b/examples/ai-agents/openclaw.mdx
@@ -35,7 +35,6 @@ This gives you a private AI assistant powered by your own GPU instance, no API k
 
 ```bash Bash
 curl -fsSL https://vast.ai/install.sh | bash
-export PATH="$HOME/.local/bin:$PATH"
 vastai set api-key YOUR_API_KEY
 ```
 

--- a/examples/ai-ml-frameworks/axolotl-fine-tuning.mdx
+++ b/examples/ai-ml-frameworks/axolotl-fine-tuning.mdx
@@ -13,7 +13,7 @@ This guide fine-tunes [Qwen2.5-3B](https://huggingface.co/Qwen/Qwen2.5-3B) with 
 - A [Vast.ai account](https://cloud.vast.ai/) with credits
 - The Vast.ai CLI installed locally:
   ```bash
-  pip install vastai
+  curl -fsSL https://vast.ai/install.sh | bash
   vastai set api-key YOUR_API_KEY
   ```
   You can find your API key at [cloud.vast.ai/cli](https://cloud.vast.ai/cli/).

--- a/examples/embeddings/serving-rerankers-vllm.mdx
+++ b/examples/embeddings/serving-rerankers-vllm.mdx
@@ -25,7 +25,7 @@ The common pattern: use embeddings to retrieve a larger candidate set quickly, t
 ## Prerequisites
 
 - Vast.ai account with credits
-- Vast.ai CLI installed (`pip install vastai`)
+- [Vast.ai CLI installed](/cli/hello-world)
 
 ## Hardware Requirements
 
@@ -40,7 +40,7 @@ The `BAAI/bge-reranker-base` model (~278M parameters) has modest requirements:
 Install and configure the Vast.ai CLI:
 
 ```bash
-pip install vastai
+curl -fsSL https://vast.ai/install.sh | bash
 vastai set api-key YOUR_API_KEY
 ```
 

--- a/examples/mcp/dr-tulu.mdx
+++ b/examples/mcp/dr-tulu.mdx
@@ -17,7 +17,7 @@ This guide covers deploying DR-Tulu-8B on Vast.ai with the complete agent stack 
 Before getting started, you'll need:
 
 - A Vast.ai account with credits ([Sign up here](https://cloud.vast.ai))
-- Vast.ai CLI installed (`pip install vastai`)
+- [Vast.ai CLI installed](/cli/hello-world)
 - Your Vast.ai API key configured
 - API keys for external services (details below)
 

--- a/examples/migrations/runpod-to-vast.mdx
+++ b/examples/migrations/runpod-to-vast.mdx
@@ -58,7 +58,6 @@ That's all you need to get started via the console. **If you plan to use the CLI
 
 ```bash Vast CLI
 curl -fsSL https://vast.ai/install.sh | bash
-export PATH="$HOME/.local/bin:$PATH"
 vastai set api-key <YOUR_API_KEY>
 ```
 

--- a/examples/migrations/runpod-to-vast.mdx
+++ b/examples/migrations/runpod-to-vast.mdx
@@ -57,7 +57,8 @@ That's all you need to get started via the console. **If you plan to use the CLI
 4. **Generate an API key** from the [Keys page](https://cloud.vast.ai/manage-keys/) and authenticate:
 
 ```bash Vast CLI
-pip install vastai
+curl -fsSL https://vast.ai/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
 vastai set api-key <YOUR_API_KEY>
 ```
 

--- a/examples/migrations/salad-to-vast.mdx
+++ b/examples/migrations/salad-to-vast.mdx
@@ -52,7 +52,6 @@ That's all you need to get started via the console. **If you plan to use the CLI
 
 ```bash Vast CLI
 curl -fsSL https://vast.ai/install.sh | bash
-export PATH="$HOME/.local/bin:$PATH"
 vastai set api-key <YOUR_API_KEY>
 ```
 

--- a/examples/migrations/salad-to-vast.mdx
+++ b/examples/migrations/salad-to-vast.mdx
@@ -51,7 +51,8 @@ That's all you need to get started via the console. **If you plan to use the CLI
 4. **Generate an API key** at [API Keys](https://cloud.vast.ai/manage-keys/) and authenticate:
 
 ```bash Vast CLI
-pip install vastai
+curl -fsSL https://vast.ai/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
 vastai set api-key <YOUR_API_KEY>
 ```
 

--- a/examples/ner/gliner2.mdx
+++ b/examples/ner/gliner2.mdx
@@ -24,7 +24,7 @@ GLiNER2 embeds both text and entity labels into the same vector space, scoring t
 Before getting started, you'll need:
 
 - A Vast.ai account with credits ([Sign up here](https://cloud.vast.ai))
-- Vast.ai CLI installed (`pip install vastai`)
+- [Vast.ai CLI installed](/cli/hello-world)
 - Docker installed locally (for building custom images)
 
 > **Note:** Get your API key from the [Vast.ai account page](https://cloud.vast.ai/account/) and set it with `vastai set api-key <your-vast-api-key>`.

--- a/examples/ocr/rolmocr.mdx
+++ b/examples/ocr/rolmocr.mdx
@@ -14,7 +14,7 @@ This guide demonstrates extracting structured pricing data from invoice images.
 ## Prerequisites
 
 - Vast.ai account with credits
-- Vast.ai CLI installed (`pip install vastai`)
+- [Vast.ai CLI installed](/cli/hello-world)
 
 ## Hardware Requirements
 
@@ -25,7 +25,7 @@ This guide demonstrates extracting structured pricing data from invoice images.
 ## Setting Up the CLI
 
 ```bash
-pip install vastai
+curl -fsSL https://vast.ai/install.sh | bash
 vastai set api-key YOUR_API_KEY
 ```
 

--- a/examples/serving-infrastructure/sglang-router-vast.mdx
+++ b/examples/serving-infrastructure/sglang-router-vast.mdx
@@ -44,7 +44,8 @@ This guide was tested with:
 
 **Install dependencies:**
 ```bash
-pip install vastai openai
+curl -fsSL https://vast.ai/install.sh | bash
+pip install openai
 ```
 
 **Configure credentials:**

--- a/examples/text-generation/glm-47-flash.mdx
+++ b/examples/text-generation/glm-47-flash.mdx
@@ -42,7 +42,7 @@ This guide uses the following configuration:
 ## Prerequisites
 
 - A [Vast.ai](https://cloud.vast.ai) account with credits
-- Vast.ai CLI installed (`pip install vastai`)
+- [Vast.ai CLI installed](/cli/hello-world)
 - Your Vast.ai API key configured (`vastai set api-key YOUR_API_KEY`)
 
 ## Step 1: Find an Instance

--- a/examples/text-generation/minimax-m2.mdx
+++ b/examples/text-generation/minimax-m2.mdx
@@ -15,7 +15,7 @@ MiniMax-M2 is a breakthrough 230 billion parameter Mixture of Experts (MoE) lang
 Before getting started, you'll need:
 
 - A Vast.ai account with credits ([Sign up here](https://cloud.vast.ai))
-- Vast.ai CLI installed (`pip install vastai`)
+- [Vast.ai CLI installed](/cli/hello-world)
 - Your Vast.ai API key configured
 - Basic familiarity with language models and APIs
 - Optional: Python knowledge for SDK integration

--- a/examples/text-generation/nemotron-3-super.mdx
+++ b/examples/text-generation/nemotron-3-super.mdx
@@ -16,7 +16,7 @@ This guide deploys the FP8 variant on Vast.ai using SGLang and queries it via th
 Before getting started, you'll need:
 
 - A Vast.ai account with credits ([Sign up here](https://cloud.vast.ai))
-- Vast.ai CLI installed (`pip install vastai`)
+- [Vast.ai CLI installed](/cli/hello-world)
 - Your Vast.ai API key configured
 - Python 3.8+ (for the OpenAI SDK examples)
 

--- a/guides/instances/connect/ssh.mdx
+++ b/guides/instances/connect/ssh.mdx
@@ -73,6 +73,7 @@ description: Learn how to securely connect to Vast.ai instances using SSH. Gener
         <CodeGroup>
          ```bash Bash
          curl -fsSL https://vast.ai/install.sh | bash
+         export PATH="$HOME/.local/bin:$PATH"
          ```
 
          ```powershell PowerShell
@@ -81,6 +82,12 @@ description: Learn how to securely connect to Vast.ai instances using SSH. Gener
          python -m pip install vastai
          ```
         </CodeGroup>
+
+        <Note>
+          The `export` line picks up `vastai` in your current terminal —
+          otherwise it's only available in new terminals opened after this
+          one. Skip it if you're starting a fresh terminal before step 3.
+        </Note>
 
     2. **Generate an API key in your vast account:**
        1. Open [CLI page](https://cloud.vast.ai/cli/)

--- a/guides/instances/connect/ssh.mdx
+++ b/guides/instances/connect/ssh.mdx
@@ -73,7 +73,6 @@ description: Learn how to securely connect to Vast.ai instances using SSH. Gener
         <CodeGroup>
          ```bash Bash
          curl -fsSL https://vast.ai/install.sh | bash
-         export PATH="$HOME/.local/bin:$PATH"
          ```
 
          ```powershell PowerShell
@@ -82,12 +81,6 @@ description: Learn how to securely connect to Vast.ai instances using SSH. Gener
          python -m pip install vastai
          ```
         </CodeGroup>
-
-        <Note>
-          The `export` line picks up `vastai` in your current terminal —
-          otherwise it's only available in new terminals opened after this
-          one. Skip it if you're starting a fresh terminal before step 3.
-        </Note>
 
     2. **Generate an API key in your vast account:**
        1. Open [CLI page](https://cloud.vast.ai/cli/)

--- a/guides/instances/connect/ssh.mdx
+++ b/guides/instances/connect/ssh.mdx
@@ -72,7 +72,7 @@ description: Learn how to securely connect to Vast.ai instances using SSH. Gener
 
         <CodeGroup>
          ```bash Bash
-         pip install vastai
+         curl -fsSL https://vast.ai/install.sh | bash
          ```
 
          ```powershell PowerShell

--- a/guides/instances/docker-environment.mdx
+++ b/guides/instances/docker-environment.mdx
@@ -200,9 +200,12 @@ If the Vast.ai CLI isn't already installed, install it with:
 
 ```bash
 curl -fsSL https://vast.ai/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
 ```
 
-Test it by starting the instance (a no-op since it's already running):
+The `export` picks up `vastai` in your current shell — the installer only
+adds it to your PATH for *new* shells, via `.bashrc`. Test it by starting
+the instance (a no-op since it's already running):
 
 ```bash
 vastai start instance $CONTAINER_ID

--- a/guides/instances/docker-environment.mdx
+++ b/guides/instances/docker-environment.mdx
@@ -200,12 +200,9 @@ If the Vast.ai CLI isn't already installed, install it with:
 
 ```bash
 curl -fsSL https://vast.ai/install.sh | bash
-export PATH="$HOME/.local/bin:$PATH"
 ```
 
-The `export` picks up `vastai` in your current shell — the installer only
-adds it to your PATH for *new* shells, via `.bashrc`. Test it by starting
-the instance (a no-op since it's already running):
+Test it by starting the instance (a no-op since it's already running):
 
 ```bash
 vastai start instance $CONTAINER_ID

--- a/guides/instances/docker-environment.mdx
+++ b/guides/instances/docker-environment.mdx
@@ -196,10 +196,10 @@ These requests map to random external ports with matching internal ports. Find t
 
 Each instance comes with a per-instance API key stored in the `CONTAINER_API_KEY` environment variable, allowing you to run CLI commands from within the container.
 
-If the Vast.ai CLI isn't already installed, install it with pip:
+If the Vast.ai CLI isn't already installed, install it with:
 
 ```bash
-pip install vastai
+curl -fsSL https://vast.ai/install.sh | bash
 ```
 
 Test it by starting the instance (a no-op since it's already running):

--- a/guides/reference/faq/instances.mdx
+++ b/guides/reference/faq/instances.mdx
@@ -76,7 +76,7 @@ A special instance API key is pre-installed. Install the CLI and use it:
 
 ```bash
 # Install CLI
-pip install vastai
+curl -fsSL https://vast.ai/install.sh | bash
 
 # Test with start (no-op if already running)
 vastai start instance $CONTAINER_ID

--- a/guides/reference/faq/instances.mdx
+++ b/guides/reference/faq/instances.mdx
@@ -77,7 +77,6 @@ A special instance API key is pre-installed. Install the CLI and use it:
 ```bash
 # Install CLI
 curl -fsSL https://vast.ai/install.sh | bash
-export PATH="$HOME/.local/bin:$PATH"  # picks up vastai in this shell now
 
 # Test with start (no-op if already running)
 vastai start instance $CONTAINER_ID

--- a/guides/reference/faq/instances.mdx
+++ b/guides/reference/faq/instances.mdx
@@ -77,6 +77,7 @@ A special instance API key is pre-installed. Install the CLI and use it:
 ```bash
 # Install CLI
 curl -fsSL https://vast.ai/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"  # picks up vastai in this shell now
 
 # Test with start (no-op if already running)
 vastai start instance $CONTAINER_ID

--- a/host/market-metrics.mdx
+++ b/host/market-metrics.mdx
@@ -29,7 +29,7 @@ Three views are available at [cloud.vast.ai/host/market/](https://cloud.vast.ai/
 Install or upgrade the CLI:
 
 ```bash
-pip install --upgrade vastai
+curl -fsSL https://vast.ai/install.sh | bash
 ```
 
 ### Current snapshot — `vastai metrics gpu`

--- a/host/market-metrics.mdx
+++ b/host/market-metrics.mdx
@@ -11,7 +11,7 @@ Vast provides real-time and historical data on GPU supply, demand, pricing, and 
 There are three ways to access market metrics:
 
 1. **Dashboards** at [cloud.vast.ai/host/market/](https://cloud.vast.ai/host/market/)
-2. **CLI** via `vastai metrics` subcommands (requires `pip install vastai`, v1.0.4+)
+2. **CLI** via `vastai metrics` subcommands (requires the [Vast CLI](/cli/hello-world), v1.0.4+)
 3. **REST API** endpoints (see [API reference](#api-endpoints) below)
 
 All three require a **host API key**. Regular client keys will receive a `401` error.

--- a/infinity-embeddings.mdx
+++ b/infinity-embeddings.mdx
@@ -17,7 +17,6 @@ This guide will show you how to setup Infinity Embeddings to serve an LLM on Vas
 
 ```bash Bash
 curl -fsSL https://vast.ai/install.sh | bash
-export PATH="$HOME/.local/bin:$PATH"
 ```
 
 Once you create your account, you can go [here](https://cloud.vast.ai/cli/) to set your API Key.

--- a/infinity-embeddings.mdx
+++ b/infinity-embeddings.mdx
@@ -16,7 +16,8 @@ One of its best features is that you can deploy multiple models on the same GPU 
 This guide will show you how to setup Infinity Embeddings to serve an LLM on Vast. We reference a note book that you can use [here](https://nbviewer.org/urls/bitbucket.org/%21api/2.0/snippets/jsbcannell/nE66og/f86a1c070ddc362abc6572eb300926a0b7190ad3/files/serve_infinity_on_vast.ipynb)
 
 ```bash Bash
-pip install --upgrade vastai
+curl -fsSL https://vast.ai/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
 ```
 
 Once you create your account, you can go [here](https://cloud.vast.ai/cli/) to set your API Key.

--- a/multi-node-training-using-torch-nccl.mdx
+++ b/multi-node-training-using-torch-nccl.mdx
@@ -24,7 +24,7 @@ This allows direct communication between the instances on all ports, which is ex
 
 ## Creating a Virtual Cluster
 
-- Install or upgrade the Vast CLI first: `pip install -U vastai`.
+- [Install or upgrade the Vast CLI](/cli/hello-world) first.
 - View physical clusters with instances matching your requirements by running `vastai search offers --raw cluster_id!=None [YOUR_INSTANCE_SEARCH_FILTERS] | grep cluster_id`
   - This will print out cluster\_ids for clusters with offers available for instances matching your search parameters.&#x20;
   - For a detailed view of the available offers within a specific cluster, run `vastai search offers cluster_id=CLUSTER_ID [YOUR_INSTANCE_SEARCH_FILTERS]`&#x20;


### PR DESCRIPTION
## Summary
- Consolidates #923 into this PR (one PR per repo).
- Fixes remaining pip-only CLI install snippets across docs — 4 P1 guides plus 15 tutorial/example docs, found via a wider grep for `pip install` + any flags + `vastai`.
- Fixes `cli/hello-world.mdx`'s verify step: PATH isn't updated in an already-running shell after either install method, so it now tells readers to open a new terminal.
- Left SDK-only install snippets and one venv-based tutorial (`overnight-ralph-loop.mdx`) unchanged — pip is correct there.