### PR TITLE
docs(examples): use curl installer in tutorial CLI install steps

### DIFF
--- a/examples/ai-agents/autoresearch.mdx
+++ b/examples/ai-agents/autoresearch.mdx
@@ -21,7 +21,8 @@ This guide walks you through setting up autoresearch on a Vast.ai GPU instance w
 Install the Vast CLI if you haven't already:
 
 ```bash
-pip install vastai
+curl -fsSL https://vast.ai/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
 vastai set api-key YOUR_API_KEY
 ```
 

--- a/examples/ai-agents/browsesafe.mdx
+++ b/examples/ai-agents/browsesafe.mdx
@@ -87,7 +87,8 @@ BrowseSafe-Bench covers 11 attack types:
 ### Step 1: Install Vast.ai CLI
 
 ```bash Bash
-pip install --upgrade vastai
+curl -fsSL https://vast.ai/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
 vastai set api-key <your-api-key>
 ```
 

--- a/examples/ai-agents/openclaw.mdx
+++ b/examples/ai-agents/openclaw.mdx
@@ -34,7 +34,8 @@ This gives you a private AI assistant powered by your own GPU instance, no API k
 ## Step 1: Install the Vast.ai CLI
 
 ```bash Bash
-pip install --upgrade vastai
+curl -fsSL https://vast.ai/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
 vastai set api-key YOUR_API_KEY
 ```
 

--- a/examples/mcp/dr-tulu.mdx
+++ b/examples/mcp/dr-tulu.mdx
@@ -17,7 +17,7 @@ This guide covers deploying DR-Tulu-8B on Vast.ai with the complete agent stack 
 Before getting started, you'll need:
 
 - A Vast.ai account with credits ([Sign up here](https://cloud.vast.ai))
-- Vast.ai CLI installed (`pip install vastai`)
+- [Vast.ai CLI installed](/cli/hello-world)
 - Your Vast.ai API key configured
 - API keys for external services (details below)
 

--- a/examples/migrations/runpod-to-vast.mdx
+++ b/examples/migrations/runpod-to-vast.mdx
@@ -57,7 +57,8 @@ That's all you need to get started via the console. **If you plan to use the CLI
 4. **Generate an API key** from the [Keys page](https://cloud.vast.ai/manage-keys/) and authenticate:
 
 ```bash Vast CLI
-pip install vastai
+curl -fsSL https://vast.ai/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
 vastai set api-key <YOUR_API_KEY>
 ```
 

--- a/examples/migrations/salad-to-vast.mdx
+++ b/examples/migrations/salad-to-vast.mdx
@@ -51,7 +51,8 @@ That's all you need to get started via the console. **If you plan to use the CLI
 4. **Generate an API key** at [API Keys](https://cloud.vast.ai/manage-keys/) and authenticate:
 
 ```bash Vast CLI
-pip install vastai
+curl -fsSL https://vast.ai/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
 vastai set api-key <YOUR_API_KEY>
 ```
 

--- a/infinity-embeddings.mdx
+++ b/infinity-embeddings.mdx
@@ -16,7 +16,8 @@ One of its best features is that you can deploy multiple models on the same GPU 
 This guide will show you how to setup Infinity Embeddings to serve an LLM on Vast. We reference a note book that you can use [here](https://nbviewer.org/urls/bitbucket.org/%21api/2.0/snippets/jsbcannell/nE66og/f86a1c070ddc362abc6572eb300926a0b7190ad3/files/serve_infinity_on_vast.ipynb)
 
 ```bash Bash
-pip install --upgrade vastai
+curl -fsSL https://vast.ai/install.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
 ```
 
 Once you create your account, you can go [here](https://cloud.vast.ai/cli/) to set your API Key.

--- a/multi-node-training-using-torch-nccl.mdx
+++ b/multi-node-training-using-torch-nccl.mdx
@@ -24,7 +24,7 @@ This allows direct communication between the instances on all ports, which is ex
 
 ## Creating a Virtual Cluster
 
-- Install or upgrade the Vast CLI first: `pip install -U vastai`.
+- [Install or upgrade the Vast CLI](/cli/hello-world) first.
 - View physical clusters with instances matching your requirements by running `vastai search offers --raw cluster_id!=None [YOUR_INSTANCE_SEARCH_FILTERS] | grep cluster_id`
   - This will print out cluster\_ids for clusters with offers available for instances matching your search parameters.&#x20;
   - For a detailed view of the available offers within a specific cluster, run `vastai search offers cluster_id=CLUSTER_ID [YOUR_INSTANCE_SEARCH_FILTERS]`&#x20;


### PR DESCRIPTION
## Summary
- Follow-up to #922 (P0/P1 CLI install docs). A wider regex sweep for `pip install[flags]vastai` (vs. the exact string used in the first pass) turned up 8 tutorial/example docs still instructing "install the Vast CLI" via pip only.
- Updated to lead with `curl -fsSL https://vast.ai/install.sh | bash` + the `export PATH="$HOME/.local/bin:$PATH"` fix (same PATH gotcha as #922 — a `vastai` command follows immediately in the same shell in most of these).
- Two prerequisite-bullet mentions (dr-tulu.mdx, multi-node-training-using-torch-nccl.mdx) were simplified to link to `/cli/hello-world` instead of inlining an install command.
- Deliberately left `examples/ai-agents/overnight-ralph-loop.mdx` unchanged — it installs `vastai` into an activated project venv alongside `aider-chat`/`pytest`, where pip is the right tool and PATH isn't an issue.

## Test plan
- [ ] Spot-check rendered pages for the 8 updated files