### PR TITLE
docs(api): document host_id filtering with notin exclusion example in search offers

### DIFF
--- a/api-reference/openapi/yaml/search_offers.yaml
+++ b/api-reference/openapi/yaml/search_offers.yaml
@@ -28,6 +28,8 @@ paths:
         | `in`     | Value is in a list     | `{ "in": ["RTX_3090", "RTX_4090"] }` |
         | `notin`  | Value is not in a list | `{ "notin": ["TW", "SE"] }`    |
 
+        For example, to exclude offers from specific hosts, filter on `host_id`: `{ "host_id": { "notin": [12345, 67890] } }`.
+
         CLI Usage: `vastai search offers 'reliability > 0.99 num_gpus>=4' --order=dph_total`
       requestBody:
         required: true
@@ -208,7 +210,13 @@ paths:
                   description: Number of direct ports
                 host_id:
                   type: object
-                  description: Host user ID
+                  description: 'Host user ID. Filter offers by host — e.g. {"eq": 12345} for a single host, or {"notin": [12345, 67890]} to exclude specific hosts from results.'
+                  properties:
+                    notin:
+                      type: array
+                      items:
+                        type: integer
+                      example: [12345, 67890]
                 id:
                   type: object
                   description: Offer ID


### PR DESCRIPTION
## What

- Expands the `host_id` property description in `search_offers.yaml` with usage examples (`eq` for a single host, `notin` to exclude hosts), plus a `notin` schema example
- Adds a host-exclusion example to the filter-operators section of the endpoint description

## Why

`host_id` is filterable in offer search — including `notin` to exclude specific hosts — and works for any API key (verified against the live API), but the schema entry read only "Host user ID" with no hint it accepts filter operators. Users wanting to avoid particular hosts had no documented way to discover this.

Companion CLI help-text PR: vast-ai/vast-cli#494

🤖 Generated with [Claude Code](https://claude.com/claude-code)