### PR TITLE
Fix create instance flag name: --price should be --bid_price

### DIFF
--- a/api-reference/creating-instances-with-api.mdx
+++ b/api-reference/creating-instances-with-api.mdx
@@ -679,7 +679,7 @@ The Vast.ai CLI provides equivalent commands for instance creation:
 - `--env ENV` - Docker options (env vars and ports)
 - `--onstart-cmd CMD` - Onstart script
 - `--label LABEL` - Instance name
-- `--price PRICE` - Bid price for interruptible instances
+- `--bid_price PRICE` - Bid price for interruptible instances
 - `--link-volume ID` - Attach an existing volume
 - `--mount-path PATH` - Volume mount path
 


### PR DESCRIPTION
The "Common create instance options" list on creating-instances-with-api documents `--price PRICE` for the bid price, but the CLI flag on `create instance` is `--bid_price` (`--price` only exists on `change bid` / `set min_bid`). Copying the documented flag as written fails with an argparse error.

One line: rename the flag in the list. Verified against `vastai create instance --help` on v1.5.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjHnozbzmdphwpQRjyk5cM