### PR TITLE
Require SSH key-only login for verification

### DIFF
--- a/host/verification-stages.mdx
+++ b/host/verification-stages.mdx
@@ -118,12 +118,18 @@ shared ISP IP cannot be used for hosting.
 | Requirement | Minimum |
 | --- | --- |
 | Operating system | Ubuntu Server 22.04 LTS, 24.04 LTS recommended |
+| SSH login | SSH keys only, password authentication disabled |
 | Secure Boot | Disabled |
 
 <Note>
 Use a server edition. Desktop editions are not supported, and Ubuntu
 releases above 24.04 are not supported yet.
 </Note>
+
+<Warning>
+SSH password login must be disabled for security. SSH password login will
+fail verification.
+</Warning>
 
 #### Storage
 

--- a/host/verification-stages.mdx
+++ b/host/verification-stages.mdx
@@ -127,8 +127,8 @@ releases above 24.04 are not supported yet.
 </Note>
 
 <Warning>
-SSH password login must be disabled for security. SSH password login will
-fail verification.
+SSH password login must be disabled for security. SSH password login enabled
+will fail verification.
 </Warning>
 
 #### Storage


### PR DESCRIPTION
## Summary

Adds SSH password login to the Minimum Requirements for Verification on `/host/verification-stages`.

- New row under **Operating system**: `SSH login | SSH keys only, password authentication disabled`
- Warning that SSH password login must be disabled, and that leaving it enabled will fail verification

## Test plan

- [x] Rendered locally on the Mintlify dev server
