### PR TITLE
Add guide for disabling SSH password login

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -621,7 +621,8 @@
               {
                 "group": "Troubleshooting",
                 "pages": [
-                  "host/machine-offline"
+                  "host/machine-offline",
+                  "host/disable-ssh-password-login"
                 ]
               }
             ]

--- a/host/disable-ssh-password-login.mdx
+++ b/host/disable-ssh-password-login.mdx
@@ -36,7 +36,8 @@ sshd enables password login when the setting is absent.
 
 ## 2. Add your key and confirm it works
 
-From your own computer:
+From your own computer. Replace `youruser` with your login name on the machine
+and `1.2.3.4` with its IP address, here and in every command below.
 
 ```bash
 ssh-copy-id youruser@1.2.3.4
@@ -46,27 +47,12 @@ ssh-copy-id youruser@1.2.3.4
 Number of key(s) added: 1
 ```
 
-This copies all of your public keys. To copy one specific key instead:
-
-```bash
-ssh-copy-id -i ~/.ssh/id_ed25519.pub youruser@1.2.3.4
-```
-
-**Now open a second terminal, leaving the first one connected, and log in using
-only your key.** This proves the key is what is getting you in.
+Now open a second terminal, leaving the first one connected, and log in using
+only your key. This proves the key is what is getting you in.
 
 ```bash
 ssh -o PreferredAuthentications=publickey youruser@1.2.3.4
 ```
-
-If you copied one specific key, test with that exact private key:
-
-```bash
-ssh -i ~/.ssh/id_ed25519 -o IdentitiesOnly=yes -o PreferredAuthentications=publickey youruser@1.2.3.4
-```
-
-`-i` picks the private key, and `IdentitiesOnly=yes` stops ssh from silently
-falling back to your other keys, so the test proves this key works.
 
 You should get a shell prompt with no password asked.
 
@@ -78,102 +64,68 @@ and that `~/.ssh` is mode `700` and `authorized_keys` is mode `600`.
 
 ## 3. Turn off password login
 
-On the host:
+<Warning>
+Do not run this until step 2 worked. If your key is not accepted yet, this locks
+you out.
+</Warning>
+
+First save a copy of the config you have now. `cp -n` never overwrites, so it is
+safe to run this more than once.
 
 ```bash
-sudo nano /etc/ssh/sshd_config
+sudo cp -n /etc/ssh/sshd_config /etc/ssh/sshd_config.orig
+sudo sh -c 'for f in /etc/ssh/sshd_config.d/*.conf; do cp -n "$f" "$f.orig"; done'
 ```
 
-Find the `PasswordAuthentication` line. Whatever the file has now, the end
-result must be one uncommented line reading exactly:
+Now set `PasswordAuthentication no` in the SSH config files that have it,
+including the extra files Ubuntu keeps in `/etc/ssh/sshd_config.d/`.
+
+```bash
+sudo sed -i -E 's/^[[:space:]]*#?[[:space:]]*(PasswordAuthentication)[[:space:]]+.*/\1 no/I' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*.conf 2>/dev/null
+```
+
+```
+(no output)
+```
+
+This catches commented lines, indented lines, and any file a cloud image left
+behind.
+
+### Or edit the config yourself
+
+Open `/etc/ssh/sshd_config` and set:
 
 ```
 PasswordAuthentication no
 ```
 
-| What the file has now | What to do |
-| --- | --- |
-| `#PasswordAuthentication yes` | Remove the `#` **and** change `yes` to `no` |
-| `PasswordAuthentication yes` | Change `yes` to `no` (it is already uncommented) |
-| `#PasswordAuthentication no` | Remove the `#` only — the value is already right |
-| No such line at all | Add a new line: `PasswordAuthentication no` |
+Then check that nothing else overrides it:
+
+```bash
+sudo grep -r -i passwordauthentication /etc/ssh/sshd_config.d/ 2>/dev/null
+```
+
+Change any line that says `yes` to `no`. Files in that folder are read first, so
+they win over the main config.
 
 <Warning>
-Removing the `#` alone is not enough. That leaves `PasswordAuthentication yes`,
-which still allows password login — as if you had changed nothing.
+Removing the `#` is not enough. The value must be `no`. A line reading
+`PasswordAuthentication yes` still allows passwords.
 </Warning>
 
-To save and exit in nano: press `Ctrl+O` then `Enter` to save the file, then
-`Ctrl+X` to exit. (Or press `Ctrl+X`, answer `Y`, then `Enter`.)
+## 4. Apply and verify
 
-## 4. Check for files that override it
-
-Ubuntu reads extra config files from `/etc/ssh/sshd_config.d/`, and they win over
-the main file. This is the most common reason the change looks done but the
-machine still fails.
-
-```bash
-sudo grep -r -i passwordauthentication /etc/ssh/sshd_config.d/ 2>/dev/null
-```
-
-No output means there is nothing to fix. Otherwise you will see something like:
-
-```
-/etc/ssh/sshd_config.d/50-cloud-init.conf:PasswordAuthentication yes
-```
-
-Edit that file and change `yes` to `no`, or delete the line. Or run this
-one-liner to fix every file in that folder at once:
-
-```bash
-sudo grep -rl -i "^PasswordAuthentication" /etc/ssh/sshd_config.d/ 2>/dev/null | xargs -r sudo sed -i 's/^PasswordAuthentication.*/PasswordAuthentication no/I'
-```
-
-Then run the check again to confirm the fix:
-
-```bash
-sudo grep -r -i passwordauthentication /etc/ssh/sshd_config.d/ 2>/dev/null
-```
-
-Every line it still prints must now say `PasswordAuthentication no`.
-
-<Note>
-`/etc/ssh/sshd_config` begins with `Include /etc/ssh/sshd_config.d/*.conf`, and
-OpenSSH keeps the first value it finds for a setting, so anything in that folder
-is read first. See the
-[Ubuntu Server OpenSSH guide](https://ubuntu.com/server/docs/how-to/security/openssh-server/).
-</Note>
-
-## 5. Test the config, then restart
-
-This command does two things, in order:
+`sshd -t` checks the config for errors. The `&&` means the restart only runs if
+that check passes, so a broken config cannot take SSH down. Editing the config
+changes nothing until you restart.
 
 ```bash
 sudo sshd -t && sudo systemctl restart ssh.service
 ```
 
-`sshd -t` test-parses the SSH config and reports any syntax error, without
-touching the running service. `&&` means the second command runs **only if**
-the first one succeeds — so if the config is broken, SSH is never restarted and
-you stay connected. `systemctl restart ssh.service` then restarts the SSH
-service so the new config actually takes effect; editing the file alone changes
-nothing until this runs.
-
 No output means both worked. Existing sessions stay connected.
 
-<Warning>
-Always run `sshd -t` before restarting. Restarting with a broken config can stop
-SSH from starting at all, leaving the console as your only way in.
-</Warning>
-
-<Note>
-Ubuntu 24.04 starts sshd on demand when a connection arrives, rather than running
-it constantly as 22.04 does. The command above is correct on both.
-</Note>
-
-## 6. Verify
-
-Confirm the running service is now refusing passwords.
+Now confirm the running service is refusing passwords:
 
 ```bash
 sudo sshd -T | grep passwordauthentication
@@ -183,23 +135,37 @@ sudo sshd -T | grep passwordauthentication
 passwordauthentication no
 ```
 
-If it still says `yes`, go back to steps 3 and 4. Then log in once more from
-your own computer to confirm, and close your original session.
+Once it says `no`, log in once more from your own computer to confirm, then
+close your original session.
 
-<Note>
-Machines are rechecked by Vast about once an hour. If yours was already flagged, the
-error can take a couple of checks to clear after you fix it.
-</Note>
+If it still says `yes`, most likely no config file had the setting. Add it,
+then restart and check again:
+
+```bash
+echo "PasswordAuthentication no" | sudo tee -a /etc/ssh/sshd_config
+sudo sshd -t && sudo systemctl restart ssh.service
+sudo sshd -T | grep passwordauthentication
+```
+
+<Check>
+Once the output is `passwordauthentication no`, you are done. If your machine
+was flagged for password login, the error clears within about two hours.
+</Check>
 
 ## If you are locked out
 
 You need access that does not go through SSH. Use the machine's IPMI, iDRAC, iLO,
-or other BMC console, or plug a monitor and keyboard into it. Then set
-`PasswordAuthentication yes` and run:
+or other BMC console, or plug a monitor and keyboard into it. Then put back
+every copy you saved in step 3, and restart:
 
 ```bash
+sudo sh -c 'for f in /etc/ssh/sshd_config.orig /etc/ssh/sshd_config.d/*.orig; do [ -e "$f" ] && cp "$f" "${f%.orig}"; done'
 sudo sshd -t && sudo systemctl restart ssh.service
 ```
+
+Restoring only `/etc/ssh/sshd_config` is not enough. The files in
+`/etc/ssh/sshd_config.d/` are read first, so they keep password login off until
+they are restored too.
 
 Log in with your password, fix your key, and start again at step 2. Password
 login has to go back off before the machine will verify.

--- a/host/disable-ssh-password-login.mdx
+++ b/host/disable-ssh-password-login.mdx
@@ -46,12 +46,27 @@ ssh-copy-id youruser@1.2.3.4
 Number of key(s) added: 1
 ```
 
-Now open a second terminal, leaving the first one connected, and log in using
-only your key. This proves the key is what is getting you in.
+This copies all of your public keys. To copy one specific key instead:
+
+```bash
+ssh-copy-id -i ~/.ssh/id_ed25519.pub youruser@1.2.3.4
+```
+
+**Now open a second terminal, leaving the first one connected, and log in using
+only your key.** This proves the key is what is getting you in.
 
 ```bash
 ssh -o PreferredAuthentications=publickey youruser@1.2.3.4
 ```
+
+If you copied one specific key, test with that exact private key:
+
+```bash
+ssh -i ~/.ssh/id_ed25519 -o IdentitiesOnly=yes -o PreferredAuthentications=publickey youruser@1.2.3.4
+```
+
+`-i` picks the private key, and `IdentitiesOnly=yes` stops ssh from silently
+falling back to your other keys, so the test proves this key works.
 
 You should get a shell prompt with no password asked.
 
@@ -69,16 +84,27 @@ On the host:
 sudo nano /etc/ssh/sshd_config
 ```
 
-Find the `PasswordAuthentication` line and set it to:
+Find the `PasswordAuthentication` line. Whatever the file has now, the end
+result must be one uncommented line reading exactly:
 
 ```
 PasswordAuthentication no
 ```
 
+| What the file has now | What to do |
+| --- | --- |
+| `#PasswordAuthentication yes` | Remove the `#` **and** change `yes` to `no` |
+| `PasswordAuthentication yes` | Change `yes` to `no` (it is already uncommented) |
+| `#PasswordAuthentication no` | Remove the `#` only — the value is already right |
+| No such line at all | Add a new line: `PasswordAuthentication no` |
+
 <Warning>
-Removing the `#` is not enough. The value must be `no`. A line reading
-`PasswordAuthentication yes` still allows passwords.
+Removing the `#` alone is not enough. That leaves `PasswordAuthentication yes`,
+which still allows password login — as if you had changed nothing.
 </Warning>
+
+To save and exit in nano: press `Ctrl+O` then `Enter` to save the file, then
+`Ctrl+X` to exit. (Or press `Ctrl+X`, answer `Y`, then `Enter`.)
 
 ## 4. Check for files that override it
 
@@ -96,7 +122,20 @@ No output means there is nothing to fix. Otherwise you will see something like:
 /etc/ssh/sshd_config.d/50-cloud-init.conf:PasswordAuthentication yes
 ```
 
-Edit that file and change `yes` to `no`, or delete the line.
+Edit that file and change `yes` to `no`, or delete the line. Or run this
+one-liner to fix every file in that folder at once:
+
+```bash
+sudo grep -rl -i "^PasswordAuthentication" /etc/ssh/sshd_config.d/ 2>/dev/null | xargs -r sudo sed -i 's/^PasswordAuthentication.*/PasswordAuthentication no/I'
+```
+
+Then run the check again to confirm the fix:
+
+```bash
+sudo grep -r -i passwordauthentication /etc/ssh/sshd_config.d/ 2>/dev/null
+```
+
+Every line it still prints must now say `PasswordAuthentication no`.
 
 <Note>
 `/etc/ssh/sshd_config` begins with `Include /etc/ssh/sshd_config.d/*.conf`, and
@@ -107,12 +146,18 @@ is read first. See the
 
 ## 5. Test the config, then restart
 
-`sshd -t` checks the file without touching the running service. Editing the file
-alone changes nothing until you restart.
+This command does two things, in order:
 
 ```bash
 sudo sshd -t && sudo systemctl restart ssh.service
 ```
+
+`sshd -t` test-parses the SSH config and reports any syntax error, without
+touching the running service. `&&` means the second command runs **only if**
+the first one succeeds — so if the config is broken, SSH is never restarted and
+you stay connected. `systemctl restart ssh.service` then restarts the SSH
+service so the new config actually takes effect; editing the file alone changes
+nothing until this runs.
 
 No output means both worked. Existing sessions stay connected.
 
@@ -138,11 +183,11 @@ sudo sshd -T | grep passwordauthentication
 passwordauthentication no
 ```
 
-If it still says `yes`, go back to step 4. Then log in once more from your own
-computer to confirm, and close your original session.
+If it still says `yes`, go back to steps 3 and 4. Then log in once more from
+your own computer to confirm, and close your original session.
 
 <Note>
-Machines are rechecked about once an hour. If yours was already flagged, the
+Machines are rechecked by Vast about once an hour. If yours was already flagged, the
 error can take a couple of checks to clear after you fix it.
 </Note>
 

--- a/host/disable-ssh-password-login.mdx
+++ b/host/disable-ssh-password-login.mdx
@@ -1,0 +1,160 @@
+---
+title: "Disable SSH Password Login"
+description: "Turn off SSH password login to protect your machine."
+---
+
+Turn off SSH password login to protect your machine. A machine with it enabled
+will not pass verification.
+
+The steps are the same on Ubuntu Server 22.04 and 24.04.
+
+<Warning>
+Do not turn off password login until you have confirmed your key works. Step 2
+is what stops you locking yourself out. Keep your current session open until the
+end.
+</Warning>
+
+## 1. Check the current setting
+
+This asks sshd what it is actually using, with defaults and included files
+resolved.
+
+```bash
+sudo sshd -T | grep passwordauthentication
+```
+
+```
+passwordauthentication yes
+```
+
+If it already says `no`, you are done. If it says `yes`, continue.
+
+<Note>
+A fresh Ubuntu install says `yes`. Ubuntu ships the setting commented out, and
+sshd enables password login when the setting is absent.
+</Note>
+
+## 2. Add your key and confirm it works
+
+From your own computer:
+
+```bash
+ssh-copy-id youruser@1.2.3.4
+```
+
+```
+Number of key(s) added: 1
+```
+
+Now open a second terminal, leaving the first one connected, and log in using
+only your key. This proves the key is what is getting you in.
+
+```bash
+ssh -o PreferredAuthentications=publickey youruser@1.2.3.4
+```
+
+You should get a shell prompt with no password asked.
+
+<Warning>
+If you get `Permission denied (publickey)`, your key is not working. Stop here
+and fix it. Check that the key landed in `~/.ssh/authorized_keys` on the host,
+and that `~/.ssh` is mode `700` and `authorized_keys` is mode `600`.
+</Warning>
+
+## 3. Turn off password login
+
+On the host:
+
+```bash
+sudo nano /etc/ssh/sshd_config
+```
+
+Find the `PasswordAuthentication` line and set it to:
+
+```
+PasswordAuthentication no
+```
+
+<Warning>
+Removing the `#` is not enough. The value must be `no`. A line reading
+`PasswordAuthentication yes` still allows passwords.
+</Warning>
+
+## 4. Check for files that override it
+
+Ubuntu reads extra config files from `/etc/ssh/sshd_config.d/`, and they win over
+the main file. This is the most common reason the change looks done but the
+machine still fails.
+
+```bash
+sudo grep -r -i passwordauthentication /etc/ssh/sshd_config.d/ 2>/dev/null
+```
+
+No output means there is nothing to fix. Otherwise you will see something like:
+
+```
+/etc/ssh/sshd_config.d/50-cloud-init.conf:PasswordAuthentication yes
+```
+
+Edit that file and change `yes` to `no`, or delete the line.
+
+<Note>
+`/etc/ssh/sshd_config` begins with `Include /etc/ssh/sshd_config.d/*.conf`, and
+OpenSSH keeps the first value it finds for a setting, so anything in that folder
+is read first. See the
+[Ubuntu Server OpenSSH guide](https://ubuntu.com/server/docs/how-to/security/openssh-server/).
+</Note>
+
+## 5. Test the config, then restart
+
+`sshd -t` checks the file without touching the running service. Editing the file
+alone changes nothing until you restart.
+
+```bash
+sudo sshd -t && sudo systemctl restart ssh.service
+```
+
+No output means both worked. Existing sessions stay connected.
+
+<Warning>
+Always run `sshd -t` before restarting. Restarting with a broken config can stop
+SSH from starting at all, leaving the console as your only way in.
+</Warning>
+
+<Note>
+Ubuntu 24.04 starts sshd on demand when a connection arrives, rather than running
+it constantly as 22.04 does. The command above is correct on both.
+</Note>
+
+## 6. Verify
+
+Confirm the running service is now refusing passwords.
+
+```bash
+sudo sshd -T | grep passwordauthentication
+```
+
+```
+passwordauthentication no
+```
+
+If it still says `yes`, go back to step 4. Then log in once more from your own
+computer to confirm, and close your original session.
+
+<Note>
+Machines are rechecked about once an hour. If yours was already flagged, the
+error can take a couple of checks to clear after you fix it.
+</Note>
+
+## If you are locked out
+
+You need access that does not go through SSH. Use the machine's IPMI, iDRAC, iLO,
+or other BMC console, or plug a monitor and keyboard into it. Then set
+`PasswordAuthentication yes` and run:
+
+```bash
+sudo sshd -t && sudo systemctl restart ssh.service
+```
+
+Log in with your password, fix your key, and start again at step 2. Password
+login has to go back off before the machine will verify.

--- a/host/verification-stages.mdx
+++ b/host/verification-stages.mdx
@@ -128,7 +128,8 @@ releases above 24.04 are not supported yet.
 
 <Warning>
 SSH password login must be disabled for security. SSH password login enabled
-will fail verification.
+will fail verification. See
+[Disable SSH Password Login](/host/disable-ssh-password-login).
 </Warning>
 
 #### Storage


### PR DESCRIPTION
## Summary

New host guide for switching a machine to SSH key only login on Ubuntu Server 22.04 and 24.04.

- Adds `host/disable-ssh-password-login.mdx`
- Adds it to the Host > Guides > Troubleshooting nav group
- Links to it from `host/verification-stages.mdx`

Six steps, each one explanation, then the command, then the output to expect. The order matters: the reader proves key login works from a second terminal before turning passwords off, so a broken key cannot lock them out. A recovery section at the end covers getting back in over IPMI, iDRAC, iLO, or a directly attached monitor and keyboard.

Two things it deliberately covers, because both are easy to miss:

- A stock Ubuntu install accepts passwords. The setting ships commented out and sshd turns password login on when it is absent, so the config file looks clean while passwords are enabled.
- A file under `/etc/ssh/sshd_config.d/` overrides the main config. `sshd_config` starts with `Include /etc/ssh/sshd_config.d/*.conf` and OpenSSH keeps the first value it finds, so editing `sshd_config` alone can have no effect. Documented in the [Ubuntu Server OpenSSH guide](https://ubuntu.com/server/docs/how-to/security/openssh-server/).

## Notes on the commands

- The key proof uses `ssh -o PreferredAuthentications=publickey`, not `-o PasswordAuthentication=no`. The latter leaves `kbdinteractiveauthentication yes` on the client, so sshd can still prompt for a password and the check would pass without the key being used.
- `sudo sshd -t` runs before every restart, so a bad config cannot take sshd down.
- `systemctl restart ssh.service` is correct on both releases. Ubuntu 24.04 socket activates sshd and 22.04 does not, but that does not change this command.

## Test plan

- [x] Renders on the Mintlify dev server
- [x] Appears under Host > Guides > Troubleshooting
- [x] `docs.json` parses
- [x] `ssh-keygen` and `ssh-copy-id` output blocks taken from real output, not paraphrased
- [x] `PreferredAuthentications=publickey` verified against the ssh client with `ssh -G`