### PR TITLE
fix(AUTO-1916): drop dead workergroup scaling params from CLI and SDK reference

### DIFF
--- a/cli/reference/create-workergroup.mdx
+++ b/cli/reference/create-workergroup.mdx
@@ -37,10 +37,6 @@ vastai create workergroup [OPTIONS]
   deployment endpoint id (allows multiple workergroups to share same deployment endpoint)
 </ParamField>
 
-<ParamField path="--test_workers" type="integer" default="3">
-  number of workers to create to get an performance estimate for while initializing workergroup (default 3)
-</ParamField>
-
 <ParamField path="--gpu_ram" type="number">
   estimated GPU RAM req  (independent of search string)
 </ParamField>
@@ -49,27 +45,11 @@ vastai create workergroup [OPTIONS]
   search param string for search offers    ex: "gpu_ram&gt;=23 num_gpus=2 gpu_name=RTX_4090 inet_down&gt;200 direct_port_count&gt;2 disk_space&gt;=64"
 </ParamField>
 
-<ParamField path="--min_load" type="number">
-  [NOTE: this field isn't currently used at the workergroup level] minimum floor load in perf units/s  (token/s for LLms)
-</ParamField>
-
-<ParamField path="--target_util" type="number">
-  [NOTE: this field isn't currently used at the workergroup level] target capacity utilization (fraction, max 1.0, default 0.9)
-</ParamField>
-
-<ParamField path="--cold_mult" type="number">
-  [NOTE: this field isn't currently used at the workergroup level]cold/stopped instance capacity target as multiple of hot capacity target (default 2.0)
-</ParamField>
-
-<ParamField path="--cold_workers" type="integer">
-  min number of workers to keep 'cold' for this workergroup
-</ParamField>
-
 ## Description
 
 Create a new autoscaling group to manage a pool of worker instances.
 
-Example: vastai create workergroup `--template_hash` HASH  `--endpoint_name` "LLama" `--test_workers` 5
+Example: vastai create workergroup `--template_hash` HASH  `--endpoint_name` "LLama"
 
 ## Examples
 

--- a/cli/reference/update-workergroup.mdx
+++ b/cli/reference/update-workergroup.mdx
@@ -19,26 +19,6 @@ vastai update workergroup WORKERGROUP_ID --endpoint_id ENDPOINT_ID [options]
 
 ## Options
 
-<ParamField path="--min_load" type="number">
-  minimum floor load in perf units/s  (token/s for LLms)
-</ParamField>
-
-<ParamField path="--target_util" type="number">
-  target capacity utilization (fraction, max 1.0, default 0.9)
-</ParamField>
-
-<ParamField path="--cold_mult" type="number">
-  cold/stopped instance capacity target as multiple of hot capacity target (default 2.5)
-</ParamField>
-
-<ParamField path="--cold_workers" type="integer">
-  min number of workers to keep 'cold' for this workergroup
-</ParamField>
-
-<ParamField path="--test_workers" type="integer">
-  number of workers to create to get an performance estimate for while initializing workergroup (default 3)
-</ParamField>
-
 <ParamField path="--gpu_ram" type="number">
   estimated GPU RAM req  (independent of search string)
 </ParamField>
@@ -73,7 +53,7 @@ vastai update workergroup WORKERGROUP_ID --endpoint_id ENDPOINT_ID [options]
 
 ## Description
 
-Example: vastai update workergroup 4242 `--min_load` 100 `--target_util` 0.9 `--cold_mult` 2.0 `--search_params` "gpu_ram&gt;=23 num_gpus=2 gpu_name=RTX_4090 inet_down&gt;200 direct_port_count&gt;2 disk_space&gt;=64" `--launch_args` "`--onstart` onstart_wget.sh  `--env` '-e ONSTART_PATH=https://s3.amazonaws.com/public.vast.ai/onstart_OOBA.sh' `--image` atinoda/text-generation-webui:default-nightly `--disk` 64" `--gpu_ram` 32.0 `--endpoint_name` "LLama" `--endpoint_id` 2
+Example: vastai update workergroup 4242 `--search_params` "gpu_ram&gt;=23 num_gpus=2 gpu_name=RTX_4090 inet_down&gt;200 direct_port_count&gt;2 disk_space&gt;=64" `--launch_args` "`--onstart` onstart_wget.sh  `--env` '-e ONSTART_PATH=https://s3.amazonaws.com/public.vast.ai/onstart_OOBA.sh' `--image` atinoda/text-generation-webui:default-nightly `--disk` 64" `--gpu_ram` 32.0 `--endpoint_name` "LLama" `--endpoint_id` 2
 
 ## Examples
 

--- a/sdk/python/reference/create-workergroup.mdx
+++ b/sdk/python/reference/create-workergroup.mdx
@@ -15,13 +15,8 @@ VastAI.create_workergroup(
     launch_args: Optional[str] = None,
     endpoint_name: Optional[str] = None,
     endpoint_id: Optional[int] = None,
-    test_workers: Optional[int] = 3,
     gpu_ram: Optional[float] = None,
-    search_params: Optional[str] = None,
-    min_load: Optional[float] = None,
-    target_util: Optional[float] = None,
-    cold_mult: Optional[float] = None,
-    cold_workers: Optional[int] = None
+    search_params: Optional[str] = None
 ) -> dict
 ```
 
@@ -51,32 +46,12 @@ VastAI.create_workergroup(
   deployment endpoint id (allows multiple workergroups to share same deployment endpoint)
 </ParamField>
 
-<ParamField path="test_workers" type="Optional[int]" default="3">
-  number of workers to create to get an performance estimate for while initializing workergroup (default 3)
-</ParamField>
-
 <ParamField path="gpu_ram" type="Optional[float]">
   estimated GPU RAM req  (independent of search string)
 </ParamField>
 
 <ParamField path="search_params" type="Optional[str]">
   search param string for search offers    ex: "gpu_ram&gt;=23 num_gpus=2 gpu_name=RTX_4090 inet_down&gt;200 direct_port_count&gt;2 disk_space&gt;=64"
-</ParamField>
-
-<ParamField path="min_load" type="Optional[float]">
-  [NOTE: this field isn't currently used at the workergroup level] minimum floor load in perf units/s  (token/s for LLms)
-</ParamField>
-
-<ParamField path="target_util" type="Optional[float]">
-  [NOTE: this field isn't currently used at the workergroup level] target capacity utilization (fraction, max 1.0, default 0.9)
-</ParamField>
-
-<ParamField path="cold_mult" type="Optional[float]">
-  [NOTE: this field isn't currently used at the workergroup level]cold/stopped instance capacity target as multiple of hot capacity target (default 2.0)
-</ParamField>
-
-<ParamField path="cold_workers" type="Optional[int]">
-  min number of workers to keep 'cold' for this workergroup
 </ParamField>
 
 ## Returns

--- a/sdk/python/reference/update-workergroup.mdx
+++ b/sdk/python/reference/update-workergroup.mdx
@@ -10,11 +10,6 @@ Update an existing autoscale worker group.
 ```python
 VastAI.update_workergroup(
     id: int,
-    min_load: Optional[float] = None,
-    target_util: Optional[float] = None,
-    cold_mult: Optional[float] = None,
-    cold_workers: Optional[int] = None,
-    test_workers: Optional[int] = None,
     gpu_ram: Optional[float] = None,
     template_hash: Optional[str] = None,
     template_id: Optional[int] = None,
@@ -30,26 +25,6 @@ VastAI.update_workergroup(
 
 <ParamField path="id" type="int" required>
   id of autoscale group to update
-</ParamField>
-
-<ParamField path="min_load" type="Optional[float]">
-  minimum floor load in perf units/s  (token/s for LLms)
-</ParamField>
-
-<ParamField path="target_util" type="Optional[float]">
-  target capacity utilization (fraction, max 1.0, default 0.9)
-</ParamField>
-
-<ParamField path="cold_mult" type="Optional[float]">
-  cold/stopped instance capacity target as multiple of hot capacity target (default 2.5)
-</ParamField>
-
-<ParamField path="cold_workers" type="Optional[int]">
-  min number of workers to keep 'cold' for this workergroup
-</ParamField>
-
-<ParamField path="test_workers" type="Optional[int]">
-  number of workers to create to get an performance estimate for while initializing workergroup (default 3)
 </ParamField>
 
 <ParamField path="gpu_ram" type="Optional[float]">


### PR DESCRIPTION
Closing step of AUTO-1909. `test_workers`, `cold_workers`, `min_load`, `target_util`, and `cold_mult` were removed from the workergroup CLI and SDK in AUTO-1898 and AUTO-1912, but the four workergroup reference pages still published all five. Anyone reading these docs would pass flags that no longer parse, or SDK kwargs that are silently dropped.

## Changes

| Page | What went |
|---|---|
| `cli/reference/create-workergroup.mdx` | 5 ParamFields + `--test_workers 5` from the example line |
| `cli/reference/update-workergroup.mdx` | 5 ParamFields + `--min_load 100 --target_util 0.9 --cold_mult 2.0` from the example line |
| `sdk/python/reference/create-workergroup.mdx` | 5 from the signature block and ParamFields |
| `sdk/python/reference/update-workergroup.mdx` | 5 from the signature block and ParamFields |

The endpoint reference pages are untouched and still document all of these. They are real there: the autoscaler reads them from the endpoint group, which is the whole reason they were removed from the workergroup.

## Why these pages weren't regenerated wholesale

These are generated by `scripts/generate_cli_sdk_docs.py` in vast-ai/vast-cli, so regeneration was the obvious approach. It turns out the published pages were produced by the **pre-revert** generator (PR #398, reverted in vast-cli `fb22a29`, relanded differently as `a19c085`). Running the current generator drops three unrelated things from the two CLI pages:

- the `## Examples` block
- the `(alias: --no-default)` note on the `-n` flag
- backtick-escaping of flags inside help text (`` `--onstart` `` becomes `--onstart`)

So the two SDK pages here are taken verbatim from the current generator (their diffs are pure removals), and the two CLI pages got targeted edits that preserve the existing rendering. Net effect is the same as regeneration for the five params, with no collateral churn.

**Worth a separate ticket:** the next person to regenerate wholesale will silently strip those three things across ~135 CLI pages. The generator should be brought back in line with the published style before that happens.

## Verification

- No workergroup reference page mentions any of the five.
- All four endpoint reference pages still do (5, 5, 8, 8 occurrences respectively).
- Diff touches exactly these four files: +3/-93.