### PR TITLE
Move the SSH password login guide under Maintenance

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -621,14 +621,14 @@
               {
                 "group": "Maintenance",
                 "pages": [
-                  "host/upgrade-kernel"
+                  "host/upgrade-kernel",
+                  "host/disable-ssh-password-login"
                 ]
               },
               {
                 "group": "Troubleshooting",
                 "pages": [
-                  "host/machine-offline",
-                  "host/disable-ssh-password-login"
+                  "host/machine-offline"
                 ]
               }
             ]


### PR DESCRIPTION
## Summary

Moves `host/disable-ssh-password-login` from the Troubleshooting group to the Maintenance group in the Host nav.

Disabling SSH password login is a hardening task a host performs once, not a response to a machine that has stopped working. It reads better beside the kernel upgrade guide than next to Offline Machine.

```
Maintenance:      host/upgrade-kernel
                  host/disable-ssh-password-login   <- moved here
Troubleshooting:  host/machine-offline
```

## Nav only

The page URL is derived from the file path, not the nav group, so the address does not change and no redirect is needed. The existing link to it from `host/verification-stages.mdx` keeps working.

## Test plan

- [x] `docs.json` parses
- [x] Rendered locally: the page's breadcrumb shows Maintenance, and the sidebar data reads `"group":"Maintenance","pages":["host/upgrade-kernel","host/disable-ssh-password-login"]`
- [x] `disable-ssh-password-login`, `verification-stages`, `machine-offline` and `upgrade-kernel` all return 200 at their existing URLs