### PR TITLE
Fix links that land readers somewhere other than their target

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -891,10 +891,6 @@
       "destination": "/cli/hello-world"
     },
     {
-      "source": "/cli/templates",
-      "destination": "/guides/templates/creating-templates"
-    },
-    {
       "source": "/sdk/python/templates",
       "destination": "/guides/templates/creating-templates"
     },
@@ -1203,10 +1199,6 @@
       "destination": "/guides/instances/pricing"
     },
     {
-      "source": "/guides/pricing",
-      "destination": "/guides/instances/pricing"
-    },
-    {
       "source": "/faq",
       "destination": "/guides/reference/faq"
     },
@@ -1415,11 +1407,11 @@
       "destination": "/api-reference/machines/schedule-maint"
     },
     {
-      "source": "/api/update-autogroup.md",
+      "source": "/api/update-autogroup",
       "destination": "/api-reference/serverless/update-workergroup"
     },
     {
-      "source": "/api/delete-autogroup.md",
+      "source": "/api/delete-autogroup",
       "destination": "/api-reference/serverless/delete-workergroup"
     },
     {
@@ -1431,11 +1423,11 @@
       "destination": "/api-reference/team/show-team-role"
     },
     {
-      "source": "/api/show-endpoints.md",
+      "source": "/api/show-endpoints",
       "destination": "/api-reference/serverless/show-endpoints"
     },
     {
-      "source": "/api/update-endpoint.md",
+      "source": "/api/update-endpoint",
       "destination": "/api-reference/serverless/update-endpoint"
     },
     {

--- a/examples/migrations/runpod-to-vast.mdx
+++ b/examples/migrations/runpod-to-vast.mdx
@@ -303,7 +303,7 @@ Vast local volumes are tied to the physical machine they were created on. For da
 
 Both platforms provide proxy access to services. On Runpod, proxy URLs are static: `https://<POD_ID>-<PORT>.proxy.runpod.net`. On Vast, there are two proxy mechanisms:
 
-- **HTTP/HTTPS proxy**: instances using [Vast base images](https://github.com/vast-ai/base-image/) get auto-generated Cloudflare tunnel URLs (`https://four-random-words.trycloudflare.com`) per open port via the [Instance Portal](/guides/instances/connect/instance-portal). These tunnels are best-effort and may not always be available; for reliable HTTPS access, use direct connections or the built-in Jupyter certificate (see [Jupyter / IDE Access](#jupyter--ide-access)).
+- **HTTP/HTTPS proxy**: instances using [Vast base images](https://github.com/vast-ai/base-image/) get auto-generated Cloudflare tunnel URLs (`https://four-random-words.trycloudflare.com`) per open port via the [Instance Portal](/guides/instances/connect/instance-portal). These tunnels are best-effort and may not always be available; for reliable HTTPS access, use direct connections or the built-in Jupyter certificate (see [Jupyter / IDE Access](#jupyter-/-ide-access)).
 - **SSH proxy**: instances using SSH-compatible images support proxy SSH through Vast's proxy server, which works even on machines without open ports. Direct SSH (faster) is preferred when available.
 
 Instances also have direct access via a **random external port** on the host's public IP, which you discover after launch.

--- a/examples/ner/gliner2.mdx
+++ b/examples/ner/gliner2.mdx
@@ -17,7 +17,7 @@ GLiNER2 embeds both text and entity labels into the same vector space, scoring t
 ## What This Guide Covers
 
 - **[Quick Start](#quick-start-using-the-pre-built-image)** - Deploy our pre-built Docker image in minutes
-- **[Full Tutorial](#tutorial-creating-docker-images-for-vastai)** - Learn how to create your own Docker images for Vast.ai
+- **[Full Tutorial](#tutorial-creating-docker-images-for-vast-ai)** - Learn how to create your own Docker images for Vast.ai
 
 ## Prerequisites
 
@@ -403,7 +403,7 @@ vastai destroy instance <INSTANCE_ID>
 ## Additional Resources
 
 - [GLiNER2 GitHub Repository](https://github.com/fastino-ai/GLiNER2)
-- [GLiNER2 Models on Hugging Face](https://huggingface.co/collections/fastino/gliner2)
+- [GLiNER2 Models on Hugging Face](https://huggingface.co/collections/fastino/gliner2-family)
 - [Vast.ai CLI Guide](/cli/hello-world)
 - [Create Your Own Template](/guides/templates/creating-templates)
 

--- a/examples/serving-infrastructure/dstack-vllm.mdx
+++ b/examples/serving-infrastructure/dstack-vllm.mdx
@@ -278,7 +278,7 @@ Remember to:
 ## Additional Resources
 
 - [dstack Documentation](https://dstack.ai/docs/)
-- [dstack CLI Reference](https://dstack.ai/docs/reference/cli/)
+- [dstack CLI Reference](https://dstack.ai/docs/reference/cli/dstack/apply/)
 - [vLLM Documentation](https://docs.vllm.ai/)
 - [Vast.ai Console](https://cloud.vast.ai/)
 - [Qwen3-30B-A3B Model Card](https://huggingface.co/Qwen/Qwen3-30B-A3B)

--- a/guides/get-started/quickstart.mdx
+++ b/guides/get-started/quickstart.mdx
@@ -26,16 +26,16 @@ This Quickstart will guide you through setting up your Vast.ai account and runni
   ![](/images/guides-overview-quick-start-2.webp)
 
 <Note>
-  Before you can **rent a machine** or **create a team**, you must [verify your email address](/guides/reference/account-settings#email-verification). After signing up, check your inbox (and spam folder) for the verification email and click the link inside. You can resend the verification email anytime from [**Settings**](/guides/reference/account-settings) → Resend Verification Email. Learn more about [teams](/guides/teams/teams-overview) and [instance management](/guides/instances/manage-instances).
+  Before you can **rent a machine** or **create a team**, you must [verify your email address](/guides/reference/account-settings#resend-verification-email). After signing up, check your inbox (and spam folder) for the verification email and click the link inside. You can resend the verification email anytime from [**Settings**](/guides/reference/account-settings) → Resend Verification Email. Learn more about [teams](/guides/teams/teams-overview) and [instance management](/guides/instances/manage-instances).
 </Note>
 
 ### &#x32;**. Prepare to Connect**
 
-- **For SSH access**: generate an [SSH key pair](/guides/instances/connect/ssh#generating-ssh-keys) following our [complete SSH guide](/guides/instances/connect/ssh) and upload your **public key** in [Keys page](https://cloud.vast.ai/manage-keys/) or via [account settings](/guides/reference/keys).
+- **For SSH access**: generate an [SSH key pair](/guides/instances/connect/ssh#quick-start-generate-and-add-your-ssh-key-to-your-vast-account) following our [complete SSH guide](/guides/instances/connect/ssh) and upload your **public key** in [Keys page](https://cloud.vast.ai/manage-keys/) or via [account settings](/guides/reference/keys).
 
 
   ![Keys](/images/guides-overview-quick-start-3.webp)
-- **For Jupyter access**: download and install the provided [TSL certificate](/guides/instances/connect/jupyter#certificate-installation) following our [Jupyter setup guide](/guides/instances/connect/jupyter) (needed for secure browser access).
+- **For Jupyter access**: download and install the provided [TSL certificate](/guides/instances/connect/jupyter#installing-the-tls-certificate) following our [Jupyter setup guide](/guides/instances/connect/jupyter) (needed for secure browser access).
 
 <Note>
   If you don’t install the provided browser certificate:&#x20;
@@ -49,15 +49,15 @@ This Quickstart will guide you through setting up your Vast.ai account and runni
   ### 3. Pick a [**Template**](/guides/templates/introduction) & Find a Machine
 
   - Browse [**Templates**](https://cloud.vast.ai/templates/) for pre-built setups (e.g., [PyTorch](/pytorch), TensorFlow, ComfyUI) or [create custom templates](/guides/templates/creating-templates).
-- Go to [**Search**](https://cloud.vast.ai/create/) and filter by GPU type, count, RAM, CPU, network speed, and price. Learn about [search filters](/guides/instances/choosing/overview#search-filters) and [instance types](/guides/instances/choosing/instance-types).
+- Go to [**Search**](https://cloud.vast.ai/create/) and filter by GPU type, count, RAM, CPU, network speed, and price. Learn about [search filters](/guides/instances/choosing/find-and-rent#layout) and [instance types](/guides/instances/choosing/instance-types).
 - **Disk Space is Permanent.** The disk size you choose when creating an instance cannot be changed later. If you run out of space, you'll need to create a new instance with a larger disk. Learn about [storage types](/guides/instances/storage/types) and [volumes](/guides/instances/storage/volumes). Tip: Allocate a bit more than you think you need to avoid interruptions.
 - Click **Rent** when you find a match. Consider [reserved instances](/guides/instances/choosing/reserved-instances) for 50% savings on long-term projects.
-- Wait for the instance to start-cached images launch quickly, fresh pulls may take 10-60 minutes. Check [instance status](/guides/instances/manage-instances#status) for progress.
+- Wait for the instance to start-cached images launch quickly, fresh pulls may take 10-60 minutes. Check [instance status](/guides/instances/manage-instances#main-status-button) for progress.
 - Click **Open** button to access your instance via your chosen [connection method](/guides/instances/connect/overview).
 
 ### **4. [Manage or End Your Instance](/guides/instances/manage-instances)**
 
-- Use **Stop** to pause GPU billing ([storage still accrues charges](/guides/instances/storage/types#costs)). Learn about the [instance lifecycle](/guides/instances/manage-instances#lifecycle).
+- Use **Stop** to pause GPU billing ([storage still accrues charges](/guides/instances/storage/types#storage-costs)). Learn about the [instance lifecycle](/guides/instances/manage-instances#instance-operations).
 - Use **Delete** when finished to stop *all* charges. See [data movement](/guides/instances/storage/data-movement) if you need to save data first.
 
 ![Manage or End Your Instance](/images/guides-overview-quick-start-4.webp)
@@ -70,7 +70,7 @@ The minimum deposit amount on Vast.ai is $5.
 
 ### What happens when my balance runs out? Can I avoid interruptions?
 
-When your balance reaches zero, your running instances will automatically stop. To avoid this, you can enable [**autobilling**](/guides/reference/billing#autobilling-credit-card-only) on the [Billing page](/guides/reference/billing). Set an auto-charge threshold higher than your average daily spend, so your card is automatically charged when your balance falls below that amount. We also recommend setting a [**low-balance email alert**](/guides/reference/account-settings#notifications) at a slightly lower threshold to notify you if the auto-charge fails for any reason. Learn more about [billing management](/guides/reference/billing) and [cost optimization](/guides/instances/pricing).
+When your balance reaches zero, your running instances will automatically stop. To avoid this, you can enable [**autobilling**](/guides/reference/billing#autobilling-credit-card-only) on the [Billing page](/guides/reference/billing). Set an auto-charge threshold higher than your average daily spend, so your card is automatically charged when your balance falls below that amount. We also recommend setting a [**low-balance email alert**](/guides/reference/account-settings#notification-settings) at a slightly lower threshold to notify you if the auto-charge fails for any reason. Learn more about [billing management](/guides/reference/billing) and [cost optimization](/guides/instances/pricing).
 
 ### How can I customize a template?
 

--- a/guides/instances/choosing/reserved-instances.mdx
+++ b/guides/instances/choosing/reserved-instances.mdx
@@ -147,6 +147,6 @@ If you stop the instance, the GPU will be released like any other instance and m
 
 ## Next Steps
 
-- Learn about other [rental types](/guides/instances/pricing#rental-types)
+- Learn about other [rental types](/guides/instances/choosing/instance-types)
 - Understand [billing basics](/guides/reference/billing)
 - View your [current instances](https://cloud.vast.ai/instances/)

--- a/guides/instances/choosing/templates.mdx
+++ b/guides/instances/choosing/templates.mdx
@@ -120,5 +120,5 @@ See the full [Templates documentation](/guides/templates/introduction) for:
 
 **Having issues?**
 - Start with a recommended template
-- Check the [Templates FAQ](/guides/reference/faq/instances#templates)
+- Check [common template issues](#common-issues)
 - Review [troubleshooting guide](/guides/reference/troubleshooting)

--- a/guides/instances/connect/instance-portal.mdx
+++ b/guides/instances/connect/instance-portal.mdx
@@ -45,7 +45,7 @@ If you would like the default application URLs to be **https\://** rather than *
 
 
 
-If you set this variable, it is important to add the Vast.ai Jupyter certificate  to your local system to avoid browser warnings.  See [this page](/guides/instances/jupyter#1SmCz) for more information about installing the certificate.
+If you set this variable, it is important to add the Vast.ai Jupyter certificate  to your local system to avoid browser warnings.  See [this page](/guides/instances/connect/jupyter#installing-the-tls-certificate) for more information about installing the certificate.
 
 ## Landing Page
 

--- a/guides/instances/storage/data-movement.mdx
+++ b/guides/instances/storage/data-movement.mdx
@@ -50,7 +50,7 @@ If the two instances are on the same machine or the same local network (same pro
 
 ### Using the GUI
 
-You can use the copy buttons to copy data between two instances. Instances can be stopped/inactive. See complete [Constraints](./#constraints)  below.
+You can use the copy buttons to copy data between two instances. Instances can be stopped/inactive. See complete [Constraints](#constraints)  below.
 
 Click the copy button on the source instance and then on the destination instance to bring up the copy dialogue. For docker-based instances you will see the following folder dialogue.
 

--- a/guides/teams/teams-quickstart.mdx
+++ b/guides/teams/teams-quickstart.mdx
@@ -26,7 +26,7 @@ There are two ways to create a team:
   ![](/images/teams-quickstart-2.webp)
 </Frame>
 
-Once there, you can create your **Team Name** and transfer some credit to your team during creation. You can also skip the credit transfer step and do it later from the [**Billing Page**](/guides/reference/billing#a6bsE).
+Once there, you can create your **Team Name** and transfer some credit to your team during creation. You can also skip the credit transfer step and do it later from the [**Billing Page**](/guides/reference/billing#transfer-credits).
 
 To add credit during team creation, select **Transfer my personal credits** checkbox, enter an amount, and then click **Create**.
 

--- a/guides/templates/advanced-setup.mdx
+++ b/guides/templates/advanced-setup.mdx
@@ -128,7 +128,7 @@ Note: Instance Portal UI is **not** required and its own config declaration can 
 
 ## Building Custom Docker Images
 
-If you want to create your own custom Docker image, you can optionally start FROM one of our [Vast.ai base images](https://hub.docker.com/r/vastai/base-image/tags) to get built-in security features and Instance Portal integration. See the [Introduction](/guides/templates/introduction#vastai-base-images) for more details on why you might want to use Vast base images.
+If you want to create your own custom Docker image, you can optionally start FROM one of our [Vast.ai base images](https://hub.docker.com/r/vastai/base-image/tags) to get built-in security features and Instance Portal integration. See the [Introduction](/guides/templates/introduction#vast-ai-base-images) for more details on why you might want to use Vast base images.
 
 ### Building FROM Vast Base Images
 

--- a/guides/templates/creating-templates.mdx
+++ b/guides/templates/creating-templates.mdx
@@ -150,7 +150,7 @@ Check out our [GROBID example](/guides/templates/examples/grobid) to see a compl
 
 1. Edit one of our recommended templates
 2. Add a PROVISIONING_SCRIPT environment variable pointing to your setup script
-3. See [Advanced Setup](/guides/templates/advanced-setup#provisioning-script) for details
+3. See [Advanced Setup](/guides/templates/advanced-setup#provisioning_script) for details
 
 ### I want to build my own custom Docker image
 

--- a/guides/templates/quickstart.mdx
+++ b/guides/templates/quickstart.mdx
@@ -40,7 +40,7 @@ You can now visit [cloud.vast.ai/instances](https://cloud.vast.ai/instances/) wh
 When it is ready you will see the blue open button.  This indicates that the instance is ready to connect.
 
 <Note>
-  The action of the open button depends on the template you have chosen - In this example you will be transferred to the [Instance Portal](/guides/instances/instance-portal). To learn how to configure Instance Portal links, see our [Advanced Setup](/guides/templates/advanced-setup#portal-config) guide.
+  The action of the open button depends on the template you have chosen - In this example you will be transferred to the [Instance Portal](/guides/instances/instance-portal). To learn how to configure Instance Portal links, see our [Advanced Setup](/guides/templates/advanced-setup#configuring-application-access-with-portal_config) guide.
 </Note>
 
 ## Next Steps

--- a/host/hosting-overview.mdx
+++ b/host/hosting-overview.mdx
@@ -114,7 +114,7 @@ The on-demand price is the price per hour for the GPU rental. On demand rentals 
 
 ### Interruptible min price (optional)
 
-The interruptible price allows for the host to set the minimum interruptible price for a client to rent. Interruptibles work in a bidding system: clients set a bid price for their instance; the current highest bid is the instance that runs, the others are paused. [more info](https://vast.ai/faq#RentalTypes)
+The interruptible price allows for the host to set the minimum interruptible price for a client to rent. Interruptibles work in a bidding system: clients set a bid price for their instance; the current highest bid is the instance that runs, the others are paused. [more info](/guides/reference/faq/rental-types)
 
 ### Reserved Discount Pricing Factor
 
@@ -244,7 +244,7 @@ To uninstall, use the Vast uninstall script located at https://s3.amazonaws.com/
 
 ### How do I host my machine(s) on Vast? How can I rent my PC?
 
-Hosting on Vast will require some Linux knowledge, as you will be maintaining a server. Our setup guide is [here](https://vast.ai/console/host/setup/). After the first paragraph of the guide there is a link to the hosting agreement. Once you agree, your account will be converted to a hosting account. You can review our [FAQ](https://vast.ai/faq/#Hosting-General) that answers many of your hosting questions.
+Hosting on Vast will require some Linux knowledge, as you will be maintaining a server. Our setup guide is [here](https://cloud.vast.ai/host/setup/). After the first paragraph of the guide there is a link to the hosting agreement. Once you agree, your account will be converted to a hosting account. You can review our [FAQ](https://vast.ai/faq/#Hosting-General) that answers many of your hosting questions.
 
 ### How do I get an invoice?
 

--- a/langflow-ollama.mdx
+++ b/langflow-ollama.mdx
@@ -8,7 +8,7 @@ updatedAt: Mon Aug 04 2025 16:28:29 GMT+0000 (Coordinated Universal Time)
 
 Langflow is a node-based agent builder you can use from your web browser.  While it integrates with many frontier language models it also has a fantastic Ollama integration which makes it really easy to use with open weight models as well as custom fine-tunes.
 
-We have two templates you can choose for this guide.  The **Langflow template** provides both Ollama and Langflow installed within the instance.  You can also use the [**Ollama standalone template**](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=Ollama) to integrate with a local langflow installation via [ssh local port forwarding](/guides/instances/sshscp#Yj5Wh).  The choice is yours. For this guide we will use the Langflow bundled template.
+We have two templates you can choose for this guide.  The **Langflow template** provides both Ollama and Langflow installed within the instance.  You can also use the [**Ollama standalone template**](https://cloud.vast.ai/?ref_id=62897&creator_id=62897&name=Ollama) to integrate with a local langflow installation via [ssh local port forwarding](/guides/instances/connect/ssh#ssh-local-port-forwarding).  The choice is yours. For this guide we will use the Langflow bundled template.
 
 Before moving on with the guide,**&#x20;Setup your Vast account and add credit**. Review the [quickstart guide](/guides/get-started/quickstart) to get familar with the service if you do not have an account with credits loaded.
 

--- a/pytorch.mdx
+++ b/pytorch.mdx
@@ -134,7 +134,7 @@ def print_gpu_utilization():
 
 ### Instance Selection
 
-- Use [vast cli search offers command ](https://vast.ai/docs/cli/reference/search-offers)to search for machines that fit your budget
+- Use [vast cli search offers command ](/cli/reference/search-offers)to search for machines that fit your budget
 - Monitor your spending in Vast.ai's Billing tab
 
 ### Resource Utilization

--- a/vllm-llm-inference-and-serving.mdx
+++ b/vllm-llm-inference-and-serving.mdx
@@ -23,7 +23,7 @@ vLLM serve is launched automatically by the template and it will use the configu
 1. Vist the [templates](https://cloud.vast.ai/templates/) page and find the recommended vLLM template.
 2. Click the pencil button to open up the template editor.
 3. If you would like to run a model other than the default, edit the `VLLM_MODEL`environment variable.  The default value is `deepseek-ai/DeepSeek-R1-Distill-Llama-8B` which is a HuggingFace repository.
-4. You can also set the arguments to pass to `vllm serve` by modifying the `VLLM_ARGS` environment variable.  vLLM is highly configurable so it's a good idea to check the official documentation before changing anything here. All available startup arguments are listed in the [official vLLM documentation](https://docs.vllm.ai/en/latest/serving/engine_args.html).
+4. You can also set the arguments to pass to `vllm serve` by modifying the `VLLM_ARGS` environment variable.  vLLM is highly configurable so it's a good idea to check the official documentation before changing anything here. All available startup arguments are listed in the [official vLLM documentation](https://docs.vllm.ai/en/latest/configuration/engine_args/).
 5. Save the template.  You will be able to find the version you have just modified in the templates page in the 'My Templates' section.
 
 ## Launch Your Instance

--- a/whisper-asr-guide.mdx
+++ b/whisper-asr-guide.mdx
@@ -22,7 +22,7 @@ updatedAt: Thu Apr 17 2025 03:30:55 GMT+0000 (Coordinated Universal Time)
 
 The template you selected will give your instance access to both Jupyter and SSH. Additionally the Open button will connect you to the instance portal web interface.&#x20;
 
-4\. HTTP and token-based auth are both enabled by default. To avoid certificate errors in your browser, please follow the instructions for installing the TLS certificate [here](/guides/instances/jupyter#1SmCz) to allow secure HTTPS connections to your instance via its IP.&#x20;
+4\. HTTP and token-based auth are both enabled by default. To avoid certificate errors in your browser, please follow the instructions for installing the TLS certificate [here](/guides/instances/connect/jupyter#installing-the-tls-certificate) to allow secure HTTPS connections to your instance via its IP.&#x20;
 
 ![](/images/use-cases-audio-to-text-3.png)
 


### PR DESCRIPTION
Sweep of every link, anchor and redirect in the repo, verified against the live site at https://docs.vast.ai. Only links that were **broken or landed on the wrong page** are changed here — a link that reaches the right page through a redirect is left alone, even where the path is stale.

## Dead anchors (19)

The fragment does not exist on the target page, so the reader lands at the top and has to hunt for the section. Mintlify keeps characters a conventional slugifier drops, so the working anchors include `#jupyter-/-ide-access`, `#provisioning_script` and `#configuring-application-access-with-portal_config`. Every replacement was taken from the `id` attributes on the rendered page, not computed.

Two legacy hashes (`#1SmCz`, `#Yj5Wh`) pre-date a page move; their paths are updated alongside the anchor, since the fix would otherwise depend on the fragment surviving a redirect.

## Link resolving to a different page

`data-movement.mdx` linked `./#constraints`, which Mintlify renders as `href="/guides/instances/storage#constraints"` — a different path, not the section further down the same page. Now `#constraints`.

## External links returning 404 (3)

| Was | Now |
| --- | --- |
| `docs.vllm.ai/en/latest/serving/engine_args.html` | `docs.vllm.ai/en/latest/configuration/engine_args/` |
| `dstack.ai/docs/reference/cli/` (no index page) | `dstack.ai/docs/reference/cli/dstack/apply/` |
| `huggingface.co/collections/fastino/gliner2` | `huggingface.co/collections/fastino/gliner2-family` |

## Links landing on a generic page instead of the one they named (3)

- `vast.ai/console/host/setup/` dropped readers on the console root → `cloud.vast.ai/host/setup/`
- `vast.ai/faq#RentalTypes` lost its section → `/guides/reference/faq/rental-types`
- `vast.ai/docs/cli/reference/search-offers` landed on the get-started guide → `/cli/reference/search-offers`

## Redirects

Mintlify resolves redirects **before** pages, so a redirect whose source matches a real page makes that page unreachable:

- `/cli/templates` and `/guides/pricing` were sending readers away from live navigation entries. `/guides/pricing` is also the target of the landing page's Pricing card. Both redirects removed so the pages they shadow can be served.
- Four sources ending in `.md` (`/api/update-autogroup.md` and three siblings) could never match — the `.md` view suffix is stripped before redirect matching, so `/api/:slug*` caught them and readers reached `/api-reference/introduction.md` instead of the endpoint page. Re-sourced without the extension.

## Verification

- 241 unique (path, anchor) targets fetched live: every anchor present in the rendered HTML, no broken links.
- All 208 redirects followed with `curl -L` to the page the reader actually lands on. A one-hop probe misreports trailing-slash normalisation, which is what produced the earlier false alarms.
- `mint@4.2.862 broken-links` reports none. Note the pinned `^4.2.234` in `package.json` cannot resolve `docs.json` redirects or OpenAPI-generated routes and reports ~145 false positives — tracked separately.

Three outcomes only take effect once this deploys and cannot be confirmed before then: `/guides/pricing` serving its page, and the four re-sourced `/api/*` redirects reaching their endpoint pages.

## Deliberately unchanged

47 links pointing at redirect sources, absolute `docs.vast.ai` self-links, and similar stale-but-working paths. They all resolve to the correct page today, so they are left as they are.