### PR TITLE
docs: add missing global CLI flags to all reference pages

### DIFF
--- a/cli/reference/attach-ssh.mdx
+++ b/cli/reference/attach-ssh.mdx
@@ -46,3 +46,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/cancel-copy.mdx
+++ b/cli/reference/cancel-copy.mdx
@@ -40,3 +40,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/cancel-sync.mdx
+++ b/cli/reference/cancel-sync.mdx
@@ -40,3 +40,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/change-bid.mdx
+++ b/cli/reference/change-bid.mdx
@@ -65,3 +65,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/clone-volume.mdx
+++ b/cli/reference/clone-volume.mdx
@@ -53,3 +53,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/cloud-copy.mdx
+++ b/cli/reference/cloud-copy.mdx
@@ -104,3 +104,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/copy.mdx
+++ b/cli/reference/copy.mdx
@@ -73,3 +73,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/create-api-key.mdx
+++ b/cli/reference/create-api-key.mdx
@@ -47,3 +47,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/create-endpoint.mdx
+++ b/cli/reference/create-endpoint.mdx
@@ -76,3 +76,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/create-env-var.mdx
+++ b/cli/reference/create-env-var.mdx
@@ -38,3 +38,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/create-instance.mdx
+++ b/cli/reference/create-instance.mdx
@@ -168,3 +168,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/create-ssh-key.mdx
+++ b/cli/reference/create-ssh-key.mdx
@@ -57,3 +57,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/create-subaccount.mdx
+++ b/cli/reference/create-subaccount.mdx
@@ -54,3 +54,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/create-team-role.mdx
+++ b/cli/reference/create-team-role.mdx
@@ -43,3 +43,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/create-team.mdx
+++ b/cli/reference/create-team.mdx
@@ -62,3 +62,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/create-template.mdx
+++ b/cli/reference/create-template.mdx
@@ -118,3 +118,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/create-volume.mdx
+++ b/cli/reference/create-volume.mdx
@@ -49,3 +49,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/create-workergroup.mdx
+++ b/cli/reference/create-workergroup.mdx
@@ -68,3 +68,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/delete-api-key.mdx
+++ b/cli/reference/delete-api-key.mdx
@@ -34,3 +34,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/delete-deployment.mdx
+++ b/cli/reference/delete-deployment.mdx
@@ -46,3 +46,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/delete-endpoint.mdx
+++ b/cli/reference/delete-endpoint.mdx
@@ -38,3 +38,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/delete-env-var.mdx
+++ b/cli/reference/delete-env-var.mdx
@@ -34,3 +34,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/delete-scheduled-job.mdx
+++ b/cli/reference/delete-scheduled-job.mdx
@@ -34,3 +34,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/delete-ssh-key.mdx
+++ b/cli/reference/delete-ssh-key.mdx
@@ -34,3 +34,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/delete-template.mdx
+++ b/cli/reference/delete-template.mdx
@@ -38,3 +38,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/delete-volume.mdx
+++ b/cli/reference/delete-volume.mdx
@@ -38,3 +38,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/delete-workergroup.mdx
+++ b/cli/reference/delete-workergroup.mdx
@@ -39,3 +39,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/destroy-instance.mdx
+++ b/cli/reference/destroy-instance.mdx
@@ -39,3 +39,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/destroy-instances.mdx
+++ b/cli/reference/destroy-instances.mdx
@@ -34,3 +34,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/destroy-team.mdx
+++ b/cli/reference/destroy-team.mdx
@@ -28,3 +28,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/detach-ssh.mdx
+++ b/cli/reference/detach-ssh.mdx
@@ -42,3 +42,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/execute.mdx
+++ b/cli/reference/execute.mdx
@@ -74,3 +74,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/get-endpt-logs.mdx
+++ b/cli/reference/get-endpt-logs.mdx
@@ -48,3 +48,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/get-wrkgrp-logs.mdx
+++ b/cli/reference/get-wrkgrp-logs.mdx
@@ -48,3 +48,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/invite-member.mdx
+++ b/cli/reference/invite-member.mdx
@@ -38,3 +38,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/label-instance.mdx
+++ b/cli/reference/label-instance.mdx
@@ -38,3 +38,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/launch-instance.mdx
+++ b/cli/reference/launch-instance.mdx
@@ -149,3 +149,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/list-volume.mdx
+++ b/cli/reference/list-volume.mdx
@@ -55,3 +55,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/list-volumes.mdx
+++ b/cli/reference/list-volumes.mdx
@@ -55,3 +55,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/logs.mdx
+++ b/cli/reference/logs.mdx
@@ -48,3 +48,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/prepay-instance.mdx
+++ b/cli/reference/prepay-instance.mdx
@@ -38,3 +38,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/reboot-instance.mdx
+++ b/cli/reference/reboot-instance.mdx
@@ -60,3 +60,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/recycle-instance.mdx
+++ b/cli/reference/recycle-instance.mdx
@@ -38,3 +38,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/remove-member.mdx
+++ b/cli/reference/remove-member.mdx
@@ -34,3 +34,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/remove-team-role.mdx
+++ b/cli/reference/remove-team-role.mdx
@@ -34,3 +34,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/reports.mdx
+++ b/cli/reference/reports.mdx
@@ -34,3 +34,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/run-benchmarks.mdx
+++ b/cli/reference/run-benchmarks.mdx
@@ -64,3 +64,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/scp-url.mdx
+++ b/cli/reference/scp-url.mdx
@@ -34,3 +34,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/search-benchmarks.mdx
+++ b/cli/reference/search-benchmarks.mdx
@@ -65,3 +65,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/search-instances.mdx
+++ b/cli/reference/search-instances.mdx
@@ -165,3 +165,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/search-invoices.mdx
+++ b/cli/reference/search-invoices.mdx
@@ -80,3 +80,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/search-offers.mdx
+++ b/cli/reference/search-offers.mdx
@@ -165,3 +165,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/search-templates.mdx
+++ b/cli/reference/search-templates.mdx
@@ -71,3 +71,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/search-volumes.mdx
+++ b/cli/reference/search-volumes.mdx
@@ -97,3 +97,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/set-api-key.mdx
+++ b/cli/reference/set-api-key.mdx
@@ -34,3 +34,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/set-user.mdx
+++ b/cli/reference/set-user.mdx
@@ -56,3 +56,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/show-api-keys.mdx
+++ b/cli/reference/show-api-keys.mdx
@@ -28,3 +28,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/show-audit-logs.mdx
+++ b/cli/reference/show-audit-logs.mdx
@@ -28,3 +28,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/show-connections.mdx
+++ b/cli/reference/show-connections.mdx
@@ -28,3 +28,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/show-deployment-versions.mdx
+++ b/cli/reference/show-deployment-versions.mdx
@@ -38,3 +38,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/show-deployment.mdx
+++ b/cli/reference/show-deployment.mdx
@@ -38,3 +38,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/show-deployments.mdx
+++ b/cli/reference/show-deployments.mdx
@@ -32,3 +32,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/show-deposit.mdx
+++ b/cli/reference/show-deposit.mdx
@@ -34,3 +34,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/show-earnings.mdx
+++ b/cli/reference/show-earnings.mdx
@@ -46,3 +46,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/show-endpoints.mdx
+++ b/cli/reference/show-endpoints.mdx
@@ -32,3 +32,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/show-env-vars.mdx
+++ b/cli/reference/show-env-vars.mdx
@@ -34,3 +34,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/show-instance.mdx
+++ b/cli/reference/show-instance.mdx
@@ -58,3 +58,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/show-instances-v1.mdx
+++ b/cli/reference/show-instances-v1.mdx
@@ -104,3 +104,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/show-instances.mdx
+++ b/cli/reference/show-instances.mdx
@@ -58,3 +58,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/show-invoices-v1.mdx
+++ b/cli/reference/show-invoices-v1.mdx
@@ -94,3 +94,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/show-ipaddrs.mdx
+++ b/cli/reference/show-ipaddrs.mdx
@@ -28,3 +28,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/show-members.mdx
+++ b/cli/reference/show-members.mdx
@@ -28,3 +28,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/show-scheduled-jobs.mdx
+++ b/cli/reference/show-scheduled-jobs.mdx
@@ -28,3 +28,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/show-ssh-keys.mdx
+++ b/cli/reference/show-ssh-keys.mdx
@@ -28,3 +28,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/show-subaccounts.mdx
+++ b/cli/reference/show-subaccounts.mdx
@@ -34,3 +34,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/show-team-role.mdx
+++ b/cli/reference/show-team-role.mdx
@@ -34,3 +34,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/show-team-roles.mdx
+++ b/cli/reference/show-team-roles.mdx
@@ -28,3 +28,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/show-user.mdx
+++ b/cli/reference/show-user.mdx
@@ -38,3 +38,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/show-volumes.mdx
+++ b/cli/reference/show-volumes.mdx
@@ -38,3 +38,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/show-workergroups.mdx
+++ b/cli/reference/show-workergroups.mdx
@@ -32,3 +32,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/ssh-url.mdx
+++ b/cli/reference/ssh-url.mdx
@@ -34,3 +34,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/start-instance.mdx
+++ b/cli/reference/start-instance.mdx
@@ -40,3 +40,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/start-instances.mdx
+++ b/cli/reference/start-instances.mdx
@@ -34,3 +34,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/stop-instance.mdx
+++ b/cli/reference/stop-instance.mdx
@@ -40,3 +40,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/stop-instances.mdx
+++ b/cli/reference/stop-instances.mdx
@@ -35,3 +35,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/transfer-credit.mdx
+++ b/cli/reference/transfer-credit.mdx
@@ -48,3 +48,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/unlist-volume.mdx
+++ b/cli/reference/unlist-volume.mdx
@@ -37,3 +37,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/update-endpoint.mdx
+++ b/cli/reference/update-endpoint.mdx
@@ -84,3 +84,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/update-env-var.mdx
+++ b/cli/reference/update-env-var.mdx
@@ -38,3 +38,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/update-instance.mdx
+++ b/cli/reference/update-instance.mdx
@@ -64,3 +64,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/update-ssh-key.mdx
+++ b/cli/reference/update-ssh-key.mdx
@@ -38,3 +38,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/update-team-role.mdx
+++ b/cli/reference/update-team-role.mdx
@@ -44,3 +44,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/update-template.mdx
+++ b/cli/reference/update-template.mdx
@@ -124,3 +124,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/update-workergroup.mdx
+++ b/cli/reference/update-workergroup.mdx
@@ -72,3 +72,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |

--- a/cli/reference/update-workers.mdx
+++ b/cli/reference/update-workers.mdx
@@ -48,3 +48,6 @@ The following options are available for all commands:
 | `--raw` | Output machine-readable JSON |
 | `--explain` | Verbose explanation of API calls |
 | `--api-key KEY` | API key (defaults to `~/.config/vastai/vast_api_key`) |
+| `--full` | Print full results instead of paging with `less` |
+| `--curl` | Show the equivalent curl command |
+| `--no-color` | Disable colored output |


### PR DESCRIPTION
## Summary

- Adds `--full`, `--curl`, and `--no-color` to the Global Options table on all 95 CLI reference pages
- The CLI defines 8 global flags but the docs only listed 5 — this adds the 3 missing ones
- Descriptions taken directly from the CLI's `argparse` definitions in `vastai/cli/main.py`

## Context

Part of #451 (docs drift). The verification script (`scripts/verify_cli_sdk_docs.py --check-params`) reports these 3 flags as `missing_from_docs` on every CLI command. This PR eliminates 285 of those parameter mismatches.

## Test plan

- [ ] Run `python scripts/verify_cli_sdk_docs.py --docs-path . --check-params --json` and confirm `--full`, `--curl`, `--no-color` no longer appear in `missing_from_docs` for any command

🤖 Generated with [Claude Code](https://claude.com/claude-code)