### PR TITLE
docs: add missing CLI parameters to 6 reference pages

### DIFF
--- a/cli/reference/delete-template.mdx
+++ b/cli/reference/delete-template.mdx
@@ -17,6 +17,10 @@ vastai delete template --template-id <id>
   Template ID of Template to Delete
 </ParamField>
 
+<ParamField path="--hash-id" type="string">
+  Hash ID of template to delete (alternative to `--template-id`)
+</ParamField>
+
 ## Description
 
 Deleting a template only removes the user's relationship to the template; it is not destroyed.

--- a/cli/reference/destroy-instance.mdx
+++ b/cli/reference/destroy-instance.mdx
@@ -17,6 +17,12 @@ vastai destroy instance id [-h] [--api-key API_KEY] [--raw]
   id of instance to delete
 </ParamField>
 
+## Options
+
+<ParamField path="-y" type="boolean">
+  Skip confirmation prompt (alias: `--yes`)
+</ParamField>
+
 ## Description
 
 Perfoms the same action as pressing the "DESTROY" button on the website at https://console.vast.ai/instances/

--- a/cli/reference/destroy-instances.mdx
+++ b/cli/reference/destroy-instances.mdx
@@ -17,6 +17,12 @@ vastai destroy instances [--raw] <id>
   ids of instance to destroy
 </ParamField>
 
+## Options
+
+<ParamField path="-y" type="boolean">
+  Skip confirmation prompt (alias: `--yes`)
+</ParamField>
+
 ## Examples
 
 ```bash

--- a/snippets/host/cli/metrics-gpu-trends.mdx
+++ b/snippets/host/cli/metrics-gpu-trends.mdx
@@ -24,6 +24,10 @@ vastai metrics gpu-trends [GPU_NAMES] [OPTIONS]
   Filter by datacenter hosting type (`true`, `false`, or `all`). Defaults to `all`.
 </ParamField>
 
+<ParamField path="--num-gpus" type="string" default="all">
+  Filter by machine GPU-count bucket. Choices: `all`, `1`, `2`, `4`, `8`.
+</ParamField>
+
 <ParamField path="--full" type="boolean">
   Return all data points instead of a sampled subset (~20 points)
 </ParamField>

--- a/snippets/host/cli/metrics-gpu.mdx
+++ b/snippets/host/cli/metrics-gpu.mdx
@@ -18,6 +18,10 @@ vastai metrics gpu [OPTIONS]
   Filter by datacenter hosting type (`true`, `false`, or `all`). Defaults to `all`.
 </ParamField>
 
+<ParamField path="--num-gpus" type="string" default="all">
+  Filter by machine GPU-count bucket. Choices: `all`, `1`, `2`, `4`, `8`.
+</ParamField>
+
 ## Description
 
 Returns a current snapshot of supply, demand, and pricing across all GPU types on the Vast marketplace. Use filters to narrow results to verified or datacenter machines.

--- a/snippets/host/cli/self-test-machine.mdx
+++ b/snippets/host/cli/self-test-machine.mdx
@@ -24,6 +24,18 @@ vastai self-test machine <machine_id> [--debugging] [--explain] [--api_key API_K
   Ignore the minimum system requirements and run the self test regardless
 </ParamField>
 
+<ParamField path="--test-image" type="string">
+  Use a custom self-test image. Overrides `VAST_SELF_TEST_IMAGE` and CUDA mapping.
+</ParamField>
+
+<ParamField path="--support-bundle-dir" type="string" default="/tmp">
+  Directory for failure diagnostic bundles.
+</ParamField>
+
+<ParamField path="--no-support-bundle" type="boolean">
+  Do not create a diagnostic tarball when the self-test fails.
+</ParamField>
+
 ## Description
 
 This command tests if a machine meets specific requirements and


### PR DESCRIPTION
## Summary

Adds undocumented CLI parameters found by auditing `--help` output against docs pages (ref: vast-ai/vast#451, batch 5 of 6):

- **metrics-gpu**, **metrics-gpu-trends**: add `--num-gpus` filter (choices: `all`, `1`, `2`, `4`, `8`)
- **self-test-machine**: add `--test-image`, `--support-bundle-dir`, `--no-support-bundle`
- **destroy-instance**, **destroy-instances**: add `-y`/`--yes` (skip confirmation prompt)
- **delete-template**: add `--hash-id` (alternative to `--template-id`)

6 files changed, 36 insertions, 0 deletions.

## Test plan
- [ ] Verify each added parameter matches current CLI `--help` output
- [ ] Confirm docs build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)