### PR TITLE
Align the hosting overview verification FAQ with the canonical page

### DIFF
--- a/host/hosting-overview.mdx
+++ b/host/hosting-overview.mdx
@@ -280,9 +280,11 @@ No, there is not an established process for hosts to message clients on Vast.
 
 ### I fear I will decrease my reliability from restarting my machine and potentially lose my verification.
 
-Restarting while a rental is active will cost you some reliability. How much depends on the uptime you have built up against the length of the downtime. Scheduling a maintenance window first keeps the penalty smaller and helps your reliability recover sooner.
+A drop in reliability does not by itself cost you your verification. What does is an active error. A machine stays de-verified while it has one, and is verified again once the error clears.
 
-A drop in reliability does not by itself cost you your verification. What does is an active error. While a machine has one it stays de-verified, and once you fix the cause the error clears and the machine is verified again.
+Restarting during an active rental does cost you reliability. Schedule a maintenance window first to keep the penalty smaller and recover sooner.
+
+See [Understanding Verification](/host/understanding-verification).
 
 ### How much can I make hosting on Vast?
 

--- a/host/hosting-overview.mdx
+++ b/host/hosting-overview.mdx
@@ -280,11 +280,9 @@ No, there is not an established process for hosts to message clients on Vast.
 
 ### I fear I will decrease my reliability from restarting my machine and potentially lose my verification.
 
-Restarting your machine does not directly affect your verification.
+Restarting during an active rental drops your reliability. How much depends on your total uptime against the downtime. Schedule a maintenance window before you restart. It reduces the penalty and your reliability recovers faster.
 
-If your machine has an error and cannot be used, it loses its verified status while that error is active. This is temporary. Once you fix the cause, the error clears on its own and the machine returns to verified.
-
-Still work carefully. It is easy to create a new error while the machine is offline.
+Errors are separate. If your machine has an error, it is de-verified until the error clears. Fix the cause and the error clears on its own.
 
 ### How much can I make hosting on Vast?
 

--- a/host/hosting-overview.mdx
+++ b/host/hosting-overview.mdx
@@ -280,7 +280,7 @@ No, there is not an established process for hosts to message clients on Vast.
 
 ### I fear I will decrease my reliability from restarting my machine and potentially lose my verification.
 
-Reliability is one of the factors verification considers, so repeated downtime can affect your standing. See [Understanding Verification](/host/understanding-verification). Whenever you take your machine offline to work on it, proceed with caution. It is easy to introduce new issues or errors that will cause your machine to be de-verified.
+Reliability does not directly affect your verification standing. But if your machine has an error and cannot be used, it is temporarily de-verified until the cause is resolved. The error then clears automatically and verification returns. Take care when working on your machine, since it is easy to introduce a new error.
 
 ### How much can I make hosting on Vast?
 

--- a/host/hosting-overview.mdx
+++ b/host/hosting-overview.mdx
@@ -254,13 +254,9 @@ You can create an invoice by going to the "Billing" page, and then click the box
 
 If your machine seems unlisted, try this command `vastai search offers 'machine_id=MACHINE_ID verified=any'` to see if the CLI finds it. If there is a result, your machine is properly listed
 
-### Can you verify my machine?
-
-Verification is conducted in a randomized and automated fashion. We only run manual verification tests are for datacenters and high end machines.
-
 ### How does verification work?
 
-Verification is mostly for higher end machines, mining rigs may never be verified. Verification is also based on supply vs demand and is machine/gpu specific. Right now the only machines which can expect fast verification are \$10k+: H100 or A100 80GB - if not tested quickly in a day or so let us know. 8x4090, 4xA6000 - should be tested in less than a week, especially if you have a number of them The only manual verification tests are for datacenters and high end machines. For everything else we run more random auto verification roughly about once a week. For datacenter partner inquiries email us at [contact@vast.ai](mailto:contact@vast.ai) directly.
+Verification is fully automated with no manual intervention. It depends on your machine's reliability, infrastructure, DLPerf score, and current supply and demand. See [Understanding Verification](/host/understanding-verification).
 
 ### How do I gain datacenter status?
 
@@ -284,7 +280,7 @@ No, there is not an established process for hosts to message clients on Vast.
 
 ### I fear I will decrease my reliability from restarting my machine and potentially lose my verification.
 
-Your machine's reliability does not directly affect your verification standing. Verification is independent of reliability. Though, whenever taking your machine offline and working on it you should procede with caution as it is easy to introduce new issues or errors that will cause your machine to be de-verified.
+Reliability is one of the factors verification considers, so repeated downtime can affect your standing. See [Understanding Verification](/host/understanding-verification). Whenever you take your machine offline to work on it, proceed with caution. It is easy to introduce new issues or errors that will cause your machine to be de-verified.
 
 ### How much can I make hosting on Vast?
 

--- a/host/hosting-overview.mdx
+++ b/host/hosting-overview.mdx
@@ -280,7 +280,11 @@ No, there is not an established process for hosts to message clients on Vast.
 
 ### I fear I will decrease my reliability from restarting my machine and potentially lose my verification.
 
-Reliability does not directly affect your verification standing. But if your machine has an error and cannot be used, it is temporarily de-verified until the cause is resolved. The error then clears automatically and verification returns. Take care when working on your machine, since it is easy to introduce a new error.
+Restarting your machine does not directly affect your verification.
+
+If your machine has an error and cannot be used, it loses its verified status while that error is active. This is temporary. Once you fix the cause, the error clears on its own and the machine returns to verified.
+
+Still work carefully. It is easy to create a new error while the machine is offline.
 
 ### How much can I make hosting on Vast?
 

--- a/host/hosting-overview.mdx
+++ b/host/hosting-overview.mdx
@@ -282,7 +282,7 @@ No, there is not an established process for hosts to message clients on Vast.
 
 Restarting while a rental is active will cost you some reliability. How much depends on the uptime you have built up against the length of the downtime. Scheduling a maintenance window first keeps the penalty smaller and helps your reliability recover sooner.
 
-Verification is separate. A machine with an active error stays de-verified while that error stands. Once you fix the cause, the error clears and the machine is verified again.
+A drop in reliability does not by itself cost you your verification. What does is an active error. While a machine has one it stays de-verified, and once you fix the cause the error clears and the machine is verified again.
 
 ### How much can I make hosting on Vast?
 

--- a/host/hosting-overview.mdx
+++ b/host/hosting-overview.mdx
@@ -280,9 +280,9 @@ No, there is not an established process for hosts to message clients on Vast.
 
 ### I fear I will decrease my reliability from restarting my machine and potentially lose my verification.
 
-Restarting during an active rental drops your reliability. How much depends on your total uptime against the downtime. Schedule a maintenance window before you restart. It reduces the penalty and your reliability recovers faster.
+Restarting while a rental is active will cost you some reliability. How much depends on the uptime you have built up against the length of the downtime. Scheduling a maintenance window first keeps the penalty smaller and helps your reliability recover sooner.
 
-Errors are separate. If your machine has an error, it is de-verified until the error clears. Fix the cause and the error clears on its own.
+Verification is separate. A machine with an active error stays de-verified while that error stands. Once you fix the cause, the error clears and the machine is verified again.
 
 ### How much can I make hosting on Vast?
 


### PR DESCRIPTION
The verification answers on the hosting overview page were out of date and contradicted [Understanding Verification](https://docs.vast.ai/host/understanding-verification), which is the source of truth.

**How does verification work?**

Merged "Can you verify my machine?" into this entry, since both asked the same thing, and replaced the answer with one sentence plus a link to the canonical page. Removed:

- the claim that manual verification tests are run for datacenters and high end machines, which contradicts "no manual intervention"
- turnaround promises by GPU model ($10k+ H100 / A100 80GB in a day, 8x4090 / 4xA6000 in a week, "roughly about once a week" otherwise)
- the `contact@vast.ai` address. Datacenter inquiries are already covered two entries below by the link to [Datacenter Status](https://docs.vast.ai/host/datacenter-status).

**I fear I will decrease my reliability from restarting my machine**

This said "Verification is independent of reliability", which understated the cost of a restart. Rewritten to state that restarting during an active rental drops reliability in proportion to total uptime against downtime, and that scheduling a maintenance window reduces the penalty and speeds recovery. Errors are called out as a separate mechanism: a machine with an error is de-verified until the error clears, which happens on its own once the cause is fixed. Also fixed a `procede` typo.

The four other `verification` mentions on the page are `verified=any` inside CLI search examples and are unchanged. No inbound links pointed at the removed `#can-you-verify-my-machine` anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
