### PR TITLE
docs: correct "Instance resumed" notification description

### DIFF
--- a/guides/reference/notifications.mdx
+++ b/guides/reference/notifications.mdx
@@ -115,9 +115,9 @@ Low-balance warnings are configured on the [Billing page](https://cloud.vast.ai/
 | Notification | What it tells you |
 | --- | --- |
 | **Instance created** | Your instance was created and is being set up. |
-| **Instance started** | Your instance is up and running for the first time. Useful when large images take a while to load. |
+| **Instance started** | Your instance is up and running for the first time. Sent once per rental, so it will not repeat if the instance stops and starts again. |
 | **Instance stopped** | Your instance was stopped. Stopped instances still incur storage charges. |
-| **Instance resumed** | Your interruptible instance got its GPU back and is running again. Reconnect and pick up your work without having to watch the console. |
+| **Instance resumed** | Your instance finished setting up and left the "Scheduling" state. Useful when a machine takes a while to hand over or a large image is still pulling. |
 | **Instance deleted** | Your instance was destroyed and its data removed. |
 | **Instance outbid** | Your interruptible instance was outbid and paused. Know right away that your job has stopped, so you can raise your bid or move the work. |
 | **Instance maintenance scheduled** | The host of your machine scheduled maintenance that will affect your instance. Checkpoint your work ahead of the window. |


### PR DESCRIPTION
The **Instance resumed** row in the notifications reference describes an interruptible-only event:

> Your interruptible instance got its GPU back and is running again.

That is not what the notification does.

- It is **not specific to interruptible instances** — it fires when any instance leaves the "Scheduling" state, which on-demand instances pass through too. As written, the description tells most users it does not apply to them.
- **"Got its GPU back" describes preemption recovery.** The actual trigger is ordinary setup finishing — a machine taking a while to hand over, or a large image still pulling.
- The notification's own subject line is *"Your Vast.ai Instance Is Now Running (Was Scheduling)"*.
- It **collided with "Instance back online"**, which is the row that genuinely means recovery after an outage. The table had two entries claiming to be the recovery event.

Also clarifies **Instance started**, which read as near-identical to "Instance resumed". The distinction users need is that it is sent once per rental and does not repeat on a later start.

No other rows touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)